### PR TITLE
Use tag for terraform-unity-eks_module ref

### DIFF
--- a/terraform-unity/modules/terraform-eks-cluster/README.md
+++ b/terraform-unity/modules/terraform-eks-cluster/README.md
@@ -21,7 +21,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module | main |
+| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module | u-sps-24.1-beta.01 |
 
 ## Resources
 

--- a/terraform-unity/modules/terraform-eks-cluster/main.tf
+++ b/terraform-unity/modules/terraform-eks-cluster/main.tf
@@ -3,7 +3,7 @@ resource "random_id" "counter" {
 }
 
 module "unity-eks" {
-  source          = "git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=main"
+  source          = "git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=u-sps-24.1-beta.01"
   deployment_name = local.cluster_name
 
   nodegroups = var.nodegroups


### PR DESCRIPTION
## Purpose

- Pin the `terraform-unity-eks_module` ref to a specific tag to get rid of terraform validate errors.

## Proposed Changes

- [CHANGE] Ref for `terraform-unity-eks_module`

## Issues

- N/A
