### PR TITLE
21 decompose sbg e2e cwl workflow

### DIFF
--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -74,6 +74,10 @@ echo_message_task = KubernetesPodOperator(
     task_id="Echo_Message",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("echo-message-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
+    container_resources=k8s.V1ResourceRequirements(
+        limits={"memory": "250M", "cpu": "100m", "ephemeral-storage": "50G"},
+        requests={"ephemeral-storage": "50G"}
+    ),
     arguments=[
         ECHO_MESSAGE_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='echo_message_args')}}"

--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -60,7 +60,7 @@ def setup(ti=None, **context):
 
 setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
 
-ECHO_MESSAGE_CWL = "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/echo.cwl"
+ECHO_MESSAGE_CWL = "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/echo_message.cwl"
 echo_message_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Echo_Message",
@@ -100,7 +100,7 @@ cat_file_task = KubernetesPodOperator(
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("cat_file-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
-        ECHO_MESSAGE_CWL,
+        CAT_FILE_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='cat_file_args')}}",
         WORKING_DIR,
     ],

--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -1,0 +1,119 @@
+# Test DAG that used CWL to invoke the busybox Docker image
+
+import json
+import uuid
+from datetime import datetime
+
+
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from kubernetes.client import models as k8s
+
+from airflow import DAG
+
+# The Kubernetes Pod that executes the CWL-Docker container
+# Must use elevated privileges to start/stop the Docker engine
+POD_TEMPLATE_FILE = "/opt/airflow/dags/docker_cwl_pod.yaml"
+
+# The Kubernetes namespace within which the Pod is run (it must already exist)
+POD_NAMESPACE = "airflow"
+
+# The path of the working directory where the CWL workflow is executed
+# (aka the starting directory for cwl-runner).
+# This is fixed to the EFS /scratch directory in this DAG.
+WORKING_DIR = "/scratch"
+
+# Default DAG configuration
+dag_default_args = {
+    "owner": "unity-sps",
+    "depends_on_past": False,
+    "start_date": datetime.utcfromtimestamp(0),
+}
+
+dag = DAG(
+    dag_id="busybox",
+    description="Test DAG using busybox",
+    tags=["Test"],
+    is_paused_upon_creation=False,
+    catchup=False,
+    schedule=None,
+    max_active_runs=100,
+    default_args=dag_default_args,
+    params={
+        "message": Param("Hello World", type="string")
+    },
+)
+
+def setup(ti=None, **context):
+
+    echo_message_dict = {
+        "message": context["params"]["message"],
+    }
+    ti.xcom_push(key="echo_message_args", value=json.dumps(echo_message_dict))
+
+    cat_file_dict = {
+        "the_file": "echo_message.txt"
+    }
+    ti.xcom_push(key="cat_file_args", value=json.dumps(cat_file_dict))
+
+
+setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
+
+ECHO_MESSAGE_CWL = "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/echo.cwl"
+echo_message_task = KubernetesPodOperator(
+    namespace=POD_NAMESPACE,
+    name="Echo_Message",
+    on_finish_action="delete_pod",
+    hostnetwork=False,
+    startup_timeout_seconds=1000,
+    get_logs=True,
+    task_id="Echo_Message",
+    full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("echo-message-pod-" + uuid.uuid4().hex))),
+    pod_template_file=POD_TEMPLATE_FILE,
+    arguments=[
+        ECHO_MESSAGE_CWL,
+        "{{ti.xcom_pull(task_ids='Setup', key='echo_message_args')}}",
+        WORKING_DIR,
+    ],
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+        )
+    ],
+    dag=dag,
+)
+
+CAT_FILE_CWL = "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/cat_file.cwl"
+cat_file_task = KubernetesPodOperator(
+    namespace=POD_NAMESPACE,
+    name="Cat_File",
+    on_finish_action="delete_pod",
+    hostnetwork=False,
+    startup_timeout_seconds=1000,
+    get_logs=True,
+    task_id="Cat_File",
+    full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("cat_file-pod-" + uuid.uuid4().hex))),
+    pod_template_file=POD_TEMPLATE_FILE,
+    arguments=[
+        ECHO_MESSAGE_CWL,
+        "{{ti.xcom_pull(task_ids='Setup', key='cat_file_args')}}",
+        WORKING_DIR,
+    ],
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+        )
+    ],
+    dag=dag,
+)
+
+setup_task >> echo_message_task >> cat_file_task

--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -133,7 +133,7 @@ echo_xcom_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         ECHO_MESSAGE_CWL,
-        "{\"message\": \"{{ ti.xcom_pull('cat_file_task')[0] }}\" }",
+        "{\"message\": \"{{ ti.xcom_pull('Cat_File')[0] }}\" }",
         WORKING_DIR,
     ],
     volume_mounts=[

--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -41,7 +41,7 @@ dag = DAG(
     max_active_runs=100,
     default_args=dag_default_args,
     params={
-        "message": Param("Hello World", type="string")
+        "message": Param("\"Hello World\"", type="string")
     },
 )
 
@@ -76,8 +76,7 @@ echo_message_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         ECHO_MESSAGE_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='echo_message_args')}}",
-        WORKING_DIR,
+        "{{ti.xcom_pull(task_ids='Setup', key='echo_message_args')}}"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -85,7 +84,7 @@ echo_message_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs")
         )
     ],
     dag=dag,
@@ -106,7 +105,7 @@ cat_file_task = KubernetesPodOperator(
     arguments=[
         CAT_FILE_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='cat_file_args')}}",
-        WORKING_DIR,
+        "cat_file.txt"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -133,8 +132,7 @@ echo_xcom_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         ECHO_MESSAGE_CWL,
-        "{\"message\": \"{{ ti.xcom_pull('Cat_File')[0] }}\" }",
-        WORKING_DIR,
+        "{\"message\": \"{{ ti.xcom_pull('Cat_File') }}\" }"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")

--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -4,7 +4,6 @@ import json
 import uuid
 from datetime import datetime
 
-
 from airflow.models.param import Param
 from airflow.operators.python import PythonOperator
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
@@ -40,10 +39,9 @@ dag = DAG(
     schedule=None,
     max_active_runs=100,
     default_args=dag_default_args,
-    params={
-        "message": Param("\"Hello World\"", type="string")
-    },
+    params={"message": Param('"Hello World"', type="string")},
 )
+
 
 # This Task creates dictionaries of data that is passed via Xcom to the downstream Tasks
 def setup(ti=None, **context):
@@ -53,12 +51,7 @@ def setup(ti=None, **context):
     }
     ti.xcom_push(key="echo_message_args", value=json.dumps(echo_message_dict))
 
-    cat_file_dict = {
-        "the_file": {
-            "class": "File",
-            "path": "echo_message.txt"
-        }
-    }
+    cat_file_dict = {"the_file": {"class": "File", "path": "echo_message.txt"}}
     ti.xcom_push(key="cat_file_args", value=json.dumps(cat_file_dict))
 
 
@@ -68,7 +61,9 @@ setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
 # This Task executes a CWL workflow that invokes the busybox Docker container.
 # to write a file in the shared '/scratch' directory.
 # It also includes an example on how to set limits on the resources used by the Pod.
-ECHO_MESSAGE_CWL = "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/echo_message.cwl"
+ECHO_MESSAGE_CWL = (
+    "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/echo_message.cwl"
+)
 echo_message_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Echo_Message",
@@ -81,19 +76,16 @@ echo_message_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     container_resources=k8s.V1ResourceRequirements(
         limits={"memory": "250M", "cpu": "100m", "ephemeral-storage": "5G"},
-        requests={"ephemeral-storage": "5G"}
+        requests={"ephemeral-storage": "5G"},
     ),
-    arguments=[
-        ECHO_MESSAGE_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='echo_message_args')}}"
-    ],
+    arguments=[ECHO_MESSAGE_CWL, "{{ti.xcom_pull(task_ids='Setup', key='echo_message_args')}}"],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
     ],
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs")
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
         )
     ],
     dag=dag,
@@ -115,11 +107,7 @@ cat_file_task = KubernetesPodOperator(
     task_id="Cat_File",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("cat_file-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    arguments=[
-        CAT_FILE_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='cat_file_args')}}",
-        "cat_file.txt"
-    ],
+    arguments=[CAT_FILE_CWL, "{{ti.xcom_pull(task_ids='Setup', key='cat_file_args')}}", "cat_file.txt"],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
     ],
@@ -130,7 +118,7 @@ cat_file_task = KubernetesPodOperator(
         )
     ],
     dag=dag,
-    do_xcom_push=True
+    do_xcom_push=True,
 )
 
 # This Task is an example on how to retrieve the Xcom data pushed by an upstream KubernetesPodOperator.
@@ -144,10 +132,7 @@ echo_xcom_task = KubernetesPodOperator(
     task_id="Echo_Xcom",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("echo-xcom-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    arguments=[
-        ECHO_MESSAGE_CWL,
-        "{\"message\": \"{{ ti.xcom_pull('Cat_File') }}\" }"
-    ],
+    arguments=[ECHO_MESSAGE_CWL, '{"message": "{{ ti.xcom_pull(\'Cat_File\') }}" }'],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
     ],

--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -53,7 +53,10 @@ def setup(ti=None, **context):
     ti.xcom_push(key="echo_message_args", value=json.dumps(echo_message_dict))
 
     cat_file_dict = {
-        "the_file": "echo_message.txt"
+        "the_file": {
+            "class": "File",
+            "path": "echo_message.txt"
+        }
     }
     ti.xcom_push(key="cat_file_args", value=json.dumps(cat_file_dict))
 

--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -64,13 +64,7 @@ dag = DAG(
             type="string",
             title="CWL workflow parameters",
             description="The job parameters encodes as a JSON string, or the URL of a JSON or YAML file",
-        ),
-        "working_dir": Param(
-            WORKING_DIR,
-            type="string",
-            title="Working directory",
-            description="Use '.' for EBS, '/scratch' for EFS",
-        ),
+        )
     },
 )
 
@@ -101,7 +95,7 @@ cwl_task = KubernetesPodOperator(
         metadata=k8s.V1ObjectMeta(name="docker-cwl-pod-" + uuid.uuid4().hex),
     ),
     pod_template_file=POD_TEMPLATE_FILE,
-    arguments=["{{ params.cwl_workflow }}", "{{ params.cwl_args }}", "{{ params.working_dir }}"],
+    arguments=["{{ params.cwl_workflow }}", "{{ params.cwl_args }}"],
     dag=dag,
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")

--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -64,7 +64,7 @@ dag = DAG(
             type="string",
             title="CWL workflow parameters",
             description="The job parameters encodes as a JSON string, or the URL of a JSON or YAML file",
-        )
+        ),
     },
 )
 

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -8,7 +8,7 @@ spec:
 
   containers:
   - name: cwl-docker
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-alpha.2
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.1
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - name: cwl-docker
     # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop42
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop45
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - name: cwl-docker
     # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop27
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop29
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -8,8 +8,8 @@ spec:
 
   containers:
   - name: cwl-docker
-    # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop46
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.3
+    # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop46
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - name: cwl-docker
     # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop29
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop42
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -8,8 +8,7 @@ spec:
 
   containers:
   - name: cwl-docker
-    # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-alpha.2
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop13
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-alpha.2
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -9,7 +9,6 @@ spec:
   containers:
   - name: cwl-docker
     image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.3
-    # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop46
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -8,7 +8,8 @@ spec:
 
   containers:
   - name: cwl-docker
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
+    # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop27
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -8,7 +8,7 @@ spec:
 
   containers:
   - name: cwl-docker
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.1
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/docker_cwl_pod.yaml
+++ b/airflow/dags/docker_cwl_pod.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - name: cwl-docker
     # image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0-beta.2
-    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop45
+    image: ghcr.io/unity-sds/unity-sps/sps-docker-cwl:develop46
     imagePullPolicy: Always
     command: ["/usr/share/cwl/docker_cwl_entrypoint.sh"]
     securityContext:

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_dag.py
@@ -100,8 +100,7 @@ cwl_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         "{{ params.cwl_workflow }}",
-        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}",
-        WORKING_DIR,
+        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}"
     ],
     # resources={"request_memory": "512Mi", "limit_memory": "1024Mi"},
     dag=dag,

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_dag.py
@@ -98,10 +98,7 @@ cwl_task = KubernetesPodOperator(
     task_id="SBG_L1_to_L2_End_To_End_CWL",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-l1-to-l2-e2e-cwl-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    arguments=[
-        "{{ params.cwl_workflow }}",
-        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}"
-    ],
+    arguments=["{{ params.cwl_workflow }}", "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}"],
     # resources={"request_memory": "512Mi", "limit_memory": "1024Mi"},
     dag=dag,
 )

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -93,7 +93,10 @@ dag = DAG(
     },
 )
 
-
+def merge_two_dicts(x, y):
+    z = x.copy()
+    z.update(y)
+    return z
 
 
 # Step: Setup
@@ -117,7 +120,7 @@ def setup(ti=None, **context):
         # "input_unity_dapa_api": context["params"]["unity_dapa_api"],
         # "output_data_bucket": context["params"]["output_data_bucket"],
     }
-    ti.xcom_push(key="preprocess_args", value=json.dumps(preprocess_dict.update(venue_dict)))
+    ti.xcom_push(key="preprocess_args", value=json.dumps(merge_two_dicts(preprocess_dict, venue_dict)))
 
     isofit_dict = {
         "input_processing_labels": INPUT_PROCESSING_LABELS,
@@ -134,15 +137,15 @@ def setup(ti=None, **context):
         "output_collection_id": context["params"]["isofit_output_collection_id"],
         "unity_stac_auth": context["params"]["unity_stac_auth"],
         "input_crid": context["params"]["crid"],
-    }.update(venue_dict)
-    ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict))
+    }
+    ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict.update(venue_dict)))
 
     resample_dict = {
         "input_stac": context["params"]["resample_input_stac"],
         "output_resample_collection_id": context["params"]["resample_output_collection_id"],
         "input_crid": context["params"]["crid"],
-    } | venue_dict
-    ti.xcom_push(key="resample_args", value=json.dumps(resample_dict))
+    }
+    ti.xcom_push(key="resample_args", value=json.dumps(resample_dict.update(venue_dict)))
 
     reflect_correct_dict = {
         "input_stac": context["params"]["reflect_correct_input_stac"],

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -112,13 +112,11 @@ def setup(ti=None, **context):
         "input_cmr_stac": context["params"]["preprocess_input_cmr_stac"],
         "output_collection_id": context["params"]["preprocess_output_collection_id"],
         "input_crid": context["params"]["crid"],
-        "input_unity_dapa_client": context["params"]["unity_dapa_client"],
-        "input_unity_dapa_api": context["params"]["unity_dapa_api"],
-        "output_data_bucket": context["params"]["output_data_bucket"],
+        # "input_unity_dapa_client": context["params"]["unity_dapa_client"],
+        # "input_unity_dapa_api": context["params"]["unity_dapa_api"],
+        # "output_data_bucket": context["params"]["output_data_bucket"],
     }
-    # FIXME
-    # } | venue_dict
-    ti.xcom_push(key="preprocess_args", value=json.dumps(preprocess_dict))
+    ti.xcom_push(key="preprocess_args", value=json.dumps(preprocess_dict.update(venue_dict)))
 
     isofit_dict = {
         "input_processing_labels": INPUT_PROCESSING_LABELS,
@@ -181,8 +179,7 @@ preprocess_task = KubernetesPodOperator(
     task_id="SBG_Preprocess",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-preprocess-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    # FIXME
-    # container_resources=CONTAINER_RESOURCES,
+    container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_PREPROCESS_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='preprocess_args')}}"
@@ -212,7 +209,7 @@ isofit_task = KubernetesPodOperator(
     task_id="SBG_Isofit",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-isofit-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    # container_resources=CONTAINER_RESOURCES,
+    container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_ISOFIT_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='isofit_args')}}"

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -62,7 +62,7 @@ dag = DAG(
         "isofit_input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
         "isofit_input_stac": Param(ISOFIT_INPUT_STAC, type="string"),
 
-        "isofit_input_aux_stac": Param("", type="string"),
+        "isofit_input_aux_stac": Param(ISOFIT_INPUT_AUX_STAC, type="string"),
         "isofit_isofit_output_collection_id": Param("ISOFIT_OUTPUT_COLLECTION_ID", type="string"),
 
         # For all steps

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -47,11 +47,6 @@ dag = DAG(
     default_args=dag_default_args,
     params={
 
-        # For step: CMR
-        #"input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
-        #"input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-        #"input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-
         # For step: PREPROCESS
         "preprocess_input_cmr_stac": Param("https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z", type="string"),
         "preprocess_output_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L1B_PRE___1", type="string"),
@@ -60,7 +55,7 @@ dag = DAG(
         "isofit_input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
         "isofit_input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
         "isofit_input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-        # "isofit_input_stac": Param("https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27", type="string"),
+        "isofit_input_stac": Param("https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27", type="string"),
         "isofit_input_aux_stac": Param('{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}', type="string"),
         "isofit_output_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_RFL___1", type="string"),
 
@@ -111,12 +106,12 @@ def setup(ti=None, **context):
         "input_cmr_collection_name": context["params"]["isofit_input_cmr_collection_name"],
         "input_cmr_search_start_time": context["params"]["isofit_input_cmr_search_start_time"],
         "input_cmr_search_stop_time": context["params"]["isofit_input_cmr_search_stop_time"],
-        # "input_stac": context["params"]["isofit_input_stac"],
+        "input_stac": context["params"]["isofit_input_stac"],
         # Output file from "preprocess" step. Path must be relative to the /scratch directory shared across tasks.
-        "input_stac": {
-            "class": "File",
-            "path": "stage_out_results.txt"
-        },
+        #"input_stac": {
+        #    "class": "File",
+        #    "path": "stage_out_results.txt"
+        #},
         "input_aux_stac": context["params"]["isofit_input_aux_stac"],
         "output_collection_id": context["params"]["isofit_output_collection_id"],
         "unity_stac_auth": context["params"]["unity_stac_auth"],
@@ -187,8 +182,8 @@ preprocess_task = KubernetesPodOperator(
 )
 
 # Step: ISOFIT
-# SBG_ISOFIT_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/isofit/sbg-isofit-workflow.cwl"
-SBG_ISOFIT_CWL = "https://raw.githubusercontent.com/LucaCinquini/sbg-workflows/devel/isofit/sbg-isofit-workflow.cwl"
+SBG_ISOFIT_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/isofit/sbg-isofit-workflow.cwl"
+# SBG_ISOFIT_CWL = "https://raw.githubusercontent.com/LucaCinquini/sbg-workflows/devel/isofit/sbg-isofit-workflow.cwl"
 isofit_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Isofit",
@@ -217,7 +212,7 @@ isofit_task = KubernetesPodOperator(
 
 # Step: RESAMPLE
 SBG_RESAMPLE_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/resample/sbg-resample-workflow.cwl"
-# SBG_RESAMPLE_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/resample/sbg-resample-workflow.dev.yml"
+SBG_RESAMPLE_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/resample/sbg-resample-workflow.dev.yml"
 resample_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Resample",
@@ -230,7 +225,8 @@ resample_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_RESAMPLE_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='resample_args')}}"
+        SBG_RESAMPLE_ARGS
+        # "{{ti.xcom_pull(task_ids='Setup', key='resample_args')}}"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -276,7 +272,7 @@ reflect_correct_task = KubernetesPodOperator(
 
 # Step: FRCOVER
 SBG_FRCOVER_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/frcover/sbg-frcover-workflow.cwl"
-# SBG_FRCOVER_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/frcover/sbg-frcover-workflow.dev.yml"
+SBG_FRCOVER_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/frcover/sbg-frcover-workflow.dev.yml"
 frcover_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Frcover",
@@ -289,7 +285,8 @@ frcover_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_FRCOVER_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='frcover_args')}}"
+        SBG_FRCOVER_ARGS
+        # "{{ti.xcom_pull(task_ids='Setup', key='frcover_args')}}"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -367,9 +367,5 @@ cleanup_task = PythonOperator(
     dag=dag
 )
 
-(setup_task >>
- preprocess_task
- >> [isofit_task, resample_task ]
- >> [reflect_correct_task, frcover_task ]
- >> cleanup_task)
+setup_task >> preprocess_task >> [isofit_task, resample_task ] >> [reflect_correct_task, frcover_task ] >> cleanup_task
 

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -367,5 +367,5 @@ cleanup_task = PythonOperator(
     dag=dag
 )
 
-setup_task >> preprocess_task >> [isofit_task, resample_task ] >> [reflect_correct_task, frcover_task ] >> cleanup_task
+setup_task >> preprocess_task >> [isofit_task >> resample_task, reflect_correct_task >> frcover_task ] >> cleanup_task
 

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -64,6 +64,8 @@ dag = DAG(
         "resample_output_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1", type="string"),
 
         # For step: REFLECT-CORRECT
+        "reflect_correct_input_stac": Param('{"type":"FeatureCollection","features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1:SISTER_EMIT_L2A_RSRFL_20240103T131936_001","properties":{"datetime":"2024-01-03T13:19:36Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-03-04T23:08:10.189899+00:00","updated":"2024-03-04T23:08:10.203265Z"},"geometry":null,"links":[{"rel":"root","href":"./catalog.json","type":"application/json"},{"rel":"parent","href":"./catalog.json","type":"application/json"}],"assets":{"SISTER_EMIT_L2A_RSRFL_20240103T131936_001.bin":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1:SISTER_EMIT_L2A_RSRFL_20240103T131936_001/SISTER_EMIT_L2A_RSRFL_20240103T131936_001.bin","title":"binary file","description":"","roles":["data"]},"SISTER_EMIT_L2A_RSRFL_20240103T131936_001.hdr":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1:SISTER_EMIT_L2A_RSRFL_20240103T131936_001/SISTER_EMIT_L2A_RSRFL_20240103T131936_001.hdr","title":"header file","description":"","roles":["data"]},"SISTER_EMIT_L2A_RSRFL_20240103T131936_001_UNC.bin":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1:SISTER_EMIT_L2A_RSRFL_20240103T131936_001/SISTER_EMIT_L2A_RSRFL_20240103T131936_001_UNC.bin","title":"binary file","description":"","roles":["data"]},"SISTER_EMIT_L2A_RSRFL_20240103T131936_001_UNC.hdr":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1:SISTER_EMIT_L2A_RSRFL_20240103T131936_001/SISTER_EMIT_L2A_RSRFL_20240103T131936_001_UNC.hdr","title":"header file","description":"","roles":["data"]},"SISTER_EMIT_L2A_RSRFL_20240103T131936_001.png":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1:SISTER_EMIT_L2A_RSRFL_20240103T131936_001/SISTER_EMIT_L2A_RSRFL_20240103T131936_001.png","title":"image/png file","description":"","roles":["browse"]},"SISTER_EMIT_L2A_RSRFL_20240103T131936_001.json":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1/urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1:SISTER_EMIT_L2A_RSRFL_20240103T131936_001/SISTER_EMIT_L2A_RSRFL_20240103T131936_001.json","title":"text/json file","description":"","roles":["metadata"]}},"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1"},{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001","properties":{"datetime":"2024-01-03T13:19:36Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-03-04T22:50:20.726229+00:00","updated":"2024-03-04T22:50:20.726712Z"},"geometry":null,"links":[{"rel":"root","href":"./catalog.json","type":"application/json"},{"rel":"parent","href":"./catalog.json","type":"application/json"}],"assets":{"SISTER_EMIT_L1B_RDN_20240103T131936_001.bin":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001.bin","title":"binary file","description":"","roles":["data"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001.hdr":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001.hdr","title":"None file","description":"","roles":["metadata"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001_LOC.bin":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001_LOC.bin","title":"binary file","description":"","roles":["data"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001_LOC.hdr":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001_LOC.hdr","title":"None file","description":"","roles":["metadata"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001_OBS.bin":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001_OBS.bin","title":"binary file","description":"","roles":["data"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001_OBS.hdr":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001_OBS.hdr","title":"None file","description":"","roles":["metadata"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001.met.json":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001.met.json","title":"None file","description":"","roles":["metadata"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001_LOC.met.json":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001_LOC.met.json","title":"None file","description":"","roles":["metadata"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001_OBS.met.json":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001_OBS.met.json","title":"None file","description":"","roles":["metadata"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001.png":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001.png","title":"image/png file","description":"","roles":["browse"]},"SISTER_EMIT_L1B_RDN_20240103T131936_001.json":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1:SISTER_EMIT_L1B_RDN_20240103T131936_001/SISTER_EMIT_L1B_RDN_20240103T131936_001.json","title":"text/json file","description":"","roles":["metadata"]}},"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-L1B_PRE___1"}]}'),
+        "reflect_correct_output_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_CORFL___1"),
 
         # For step: FRCOVER
         "frcover_input_stac": Param("https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L2A_CORFL___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27", type="string"),
@@ -129,6 +131,16 @@ def setup(ti=None, **context):
         "output_data_bucket": context["params"]["output_data_bucket"],
     }
     ti.xcom_push(key="resample_args", value=json.dumps(resample_dict))
+
+    reflect_correct_dict = {
+        "input_stac": context["params"]["reflect_correct_input_stac"],
+        "output_collection_id": context["params"]["reflect_correct_output_collection_id"],
+        "input_unity_dapa_client": context["params"]["unity_dapa_client"],
+        "input_unity_dapa_api": context["params"]["unity_dapa_api"],
+        "input_crid": context["params"]["crid"],
+        "output_data_bucket": context["params"]["output_data_bucket"],
+    }
+    ti.xcom_push(key="reflect_correct_args", value=json.dumps(reflect_correct_dict))
 
     frcover_dict = {
         # Output file from "reflect-correct" step.
@@ -238,7 +250,7 @@ resample_task = KubernetesPodOperator(
 
 # Step: REFLECT-CORRECT
 SBG_REFLECT_CORRECT_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/reflect-correct/sbg-reflect-correct-workflow.cwl"
-SBG_REFLECT_CORRECT_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/reflect-correct/sbg-reflect-correct-workflow.dev.yml"
+# SBG_REFLECT_CORRECT_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/reflect-correct/sbg-reflect-correct-workflow.dev.yml"
 reflect_correct_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Reflect_Correct",
@@ -251,7 +263,8 @@ reflect_correct_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_REFLECT_CORRECT_CWL,
-        SBG_REFLECT_CORRECT_ARGS
+        # SBG_REFLECT_CORRECT_ARGS
+        "{{ti.xcom_pull(task_ids='Setup', key='reflect_correct_args')}}"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -321,7 +334,8 @@ cleanup_on_failure_task = PythonOperator(
     dag=dag
 )
 
-(setup_task >>
- preprocess_task >> isofit_task >> resample_task >> reflect_correct_task >> frcover_task >>
+# FIXME
+(setup_task >> reflect_correct_task >>
+ preprocess_task >> isofit_task >> resample_task >> frcover_task >>
  [cleanup_on_success_task, cleanup_on_failure_task])
 

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -98,7 +98,10 @@ def setup(ti=None, **context):
     preprocess_dict = {
         "input_processing_labels": ["label1", "label2"],
         # Note: must pass the path RELATIVE to te working directory - not the absolute path on the Pod
-        "input_cmr_stac": "cmr-results.json",
+        "input_cmr_stac": {
+            "class": "File",
+            "path": "cmr-results.json",
+        },
         "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
         "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
         "input_crid": context["params"]["input_crid"],

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -30,12 +30,15 @@ dag_default_args = {
     "start_date": datetime.utcfromtimestamp(0),
 }
 
-INPUT_AUX_STAC = '{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}'
-INPUT_CMR_STAC = "https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z"
+PREPROCESS_INPUT_AUX_STAC = '{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}'
+
+ISOFIT_INPUT_STAC = "https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27"
+ISOFIT_INPUT_AUX_STAC = '{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}'
+ISOFIT_OUTPUT_COLLECTION_ID = "urn:nasa:unity:unity:dev:SBG-L2A_RFL___1"
 
 DAPA_CLIENT_DEV_VENUE = "40c2s0ulbhp9i0fmaph3su9jch"
 DAPA_API_DEV_VENUE = "https://d3vc8w9zcq658.cloudfront.net"
-OUTPUT_COLLECTION_ID = "urn:nasa:unity:unity:dev:SBG-L1B_PRE___1"
+PREPROCESS_OUTPUT_COLLECTION_ID = "urn:nasa:unity:unity:dev:SBG-L1B_PRE___1"
 OUTPUT_DATA_BUCKET = "sps-dev-ds-storage"
 
 dag = DAG(
@@ -48,59 +51,65 @@ dag = DAG(
     max_active_runs=100,
     default_args=dag_default_args,
     params={
-        # For Preprocess step
-        "input_cmr_stac": Param(INPUT_CMR_STAC, type="string"),
+
+        # PREPROCESS step
+        "preprocess_input_cmr_stac": Param(PREPROCESS_INPUT_AUX_STAC, type="string"),
+        "preprocess_output_collection_id": Param(PREPROCESS_OUTPUT_COLLECTION_ID, type="string"),
+
+        # ISOFIT  Step
+        "isofit_input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
+        "isofit_input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+        "isofit_input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+        "isofit_input_stac": Param(ISOFIT_INPUT_STAC, type="string"),
+
+        "isofit_input_aux_stac": Param("", type="string"),
+        "isofit_isofit_output_collection_id": Param("ISOFIT_OUTPUT_COLLECTION_ID", type="string"),
+
+        # For all steps
         "input_unity_dapa_client": Param(DAPA_CLIENT_DEV_VENUE, type="string"),
         "input_unity_dapa_api": Param(DAPA_API_DEV_VENUE, type="string"),
+        "output_data_bucket": Param(OUTPUT_DATA_BUCKET, type="string"),
         "input_crid": Param("001", type="string"),
-        "output_collection_id": Param(OUTPUT_COLLECTION_ID, type="string"),
-        "output_data_bucket": Param(OUTPUT_DATA_BUCKET, type="string")
+        "unity_stac_auth": Param("UNITY", type="string"),
 
-        # For CMR Search Step
-        # "input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
-        # "input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-        # "input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-
-        # For unity data upload step, unity catalog
-        # "output_preprocess_collection_id": Param("40c2s0ulbhp9i0fmaph3su9jch", type="string"),
-        # "input_aux_stac": Param(INPUT_AUX_STAC, type="string"),
-        # For unity data upload step, unity catalog
-        # "output_isofit_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_RFL___1", type="string"),
-        # "output_resample_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1", type="string"),
-        # "output_refcorrect_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_CORFL___1", type="string"),
     },
 )
 
 
 # Task that serializes the job arguments into a JSON string
 def setup(ti=None, **context):
-    task_dict = {
+
+    preprocess_dict = {
         "input_processing_labels": ["label1", "label2"],
-        "input_cmr_stac": context["params"]["input_cmr_stac"],
+        "input_cmr_stac": context["params"]["preprocess_input_cmr_stac"],
         "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
         "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
         "input_crid": context["params"]["input_crid"],
-        "output_collection_id": context["params"]["output_collection_id"],
+        "output_collection_id": context["params"]["preprocess_output_collection_id"],
         "output_data_bucket": context["params"]["output_data_bucket"],
-        # "input_cmr_collection_name": context["params"]["input_cmr_collection_name"],
-        # "input_cmr_search_start_time": context["params"]["input_cmr_search_start_time"],
-        ###"input_cmr_search_stop_time": context["params"]["input_cmr_search_stop_time"],
-        # "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
-        # "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
-        # "input_crid": context["params"]["input_crid"],
-        # "output_preprocess_collection_id": context["params"]["output_preprocess_collection_id"],
-        # "output_data_bucket": context["params"]["output_data_bucket"],
-        # "input_aux_stac": context["params"]["input_aux_stac"],
-        # "output_isofit_collection_id": context["params"]["output_isofit_collection_id"],
-        # "output_resample_collection_id": context["params"]["output_resample_collection_id"],
-        # "output_refcorrect_collection_id": context["params"]["output_refcorrect_collection_id"],
     }
-    ti.xcom_push(key="cwl_args", value=json.dumps(task_dict))
+    ti.xcom_push(key="preprocess_args", value=json.dumps(preprocess_dict))
+
+    isofit_dict = {
+        "input_processing_labels": ["label1", "label2"],
+        "input_cmr_collection_name": context["params"]["isofit_input_cmr_collection_name"],
+        "input_cmr_search_start_time": context["params"]["isofit_input_cmr_search_start_time"],
+        "input_cmr_search_stop_time": context["params"]["isofit_input_cmr_search_stop_time"],
+        "input_stac": context["params"]["isofit_input_stac"],
+        "unity_stac_auth": context["params"]["unity_stac_auth"],
+        "input_aux_stac": context["params"]["isofit_input_aux_stac"],
+        "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
+        "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
+        "input_crid": context["params"]["input_crid"],
+        "output_collection_id": context["params"]["isofit_output_collection_id"],
+        "output_data_bucket": context["params"]["isofit_output_collection_id"],
+    }
+    ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict))
 
 
 setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
 
-# Step: Preprocess
+# Step: PREPROCESS
 SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
 preprocess_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
@@ -114,7 +123,7 @@ preprocess_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_PREPROCESS_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}",
+        "{{ti.xcom_pull(task_ids='Setup', key='preprocess_args')}}",
         WORKING_DIR,
     ],
     volume_mounts=[
@@ -129,4 +138,33 @@ preprocess_task = KubernetesPodOperator(
     dag=dag,
 )
 
-setup_task >> preprocess_task
+# Step: ISOFIT
+SBG_ISOFIT_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/isofit/sbg-isofit-workflow.cwl"
+isofit_task = KubernetesPodOperator(
+    namespace=POD_NAMESPACE,
+    name="Isofit",
+    on_finish_action="delete_pod",
+    hostnetwork=False,
+    startup_timeout_seconds=1000,
+    get_logs=True,
+    task_id="SBG_Isofit",
+    full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-isofit-pod-" + uuid.uuid4().hex))),
+    pod_template_file=POD_TEMPLATE_FILE,
+    arguments=[
+        SBG_ISOFIT_CWL,
+        "{{ti.xcom_pull(task_ids='Setup', key='isofit_args')}}",
+        WORKING_DIR,
+    ],
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+        )
+    ],
+    dag=dag,
+)
+
+setup_task >> preprocess_task >> isofit_task

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -347,6 +347,7 @@ def cleanup(**context):
 
 
 # Must have 2 cleanup tasks for the success and failure scenarios
+'''
 cleanup_on_success_task = PythonOperator(
     task_id="Cleanup_On_Success",
     python_callable=cleanup,
@@ -355,17 +356,20 @@ cleanup_on_success_task = PythonOperator(
     weight_rule='upstream',
     dag=dag
 )
+'''
 
-cleanup_on_failure_task = PythonOperator(
+cleanup_task = PythonOperator(
     task_id="Cleanup_On_Failure",
     python_callable=cleanup,
-    trigger_rule=TriggerRule.ONE_FAILED,
+    trigger_rule=TriggerRule.ALL_DONE,
     priority_weight=1,
     weight_rule='upstream',
     dag=dag
 )
 
 (setup_task >>
- preprocess_task >> [isofit_task, resample_task ] >> [reflect_correct_task, frcover_task ] >>
- [cleanup_on_success_task, cleanup_on_failure_task])
+ preprocess_task
+ >> [isofit_task, resample_task ]
+ >> [reflect_correct_task, frcover_task ]
+ >> cleanup_task)
 

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -36,11 +36,6 @@ dag_default_args = {
 # common parameters
 INPUT_PROCESSING_LABELS = ["label1", "label2"]
 
-class CwlKubernetesPodOperator(KubernetesPodOperator):
-    def __init__(self, *args, **kwargs):
-        super(KubernetesPodOperator, self).__init__(*args, **kwargs)
-
-
 dag = DAG(
     dag_id="sbg-l1-to-l2-e2e-cwl-step-by-step-dag",
     description="SBG L1 to L2 End-To-End Workflow as step-by-step CWL DAGs",
@@ -156,7 +151,7 @@ cmr_task = KubernetesPodOperator(
 
 # Step: PREPROCESS
 SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
-preprocess_task = CwlKubernetesPodOperator(
+preprocess_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Preprocess",
     on_finish_action="delete_pod",

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -137,7 +137,7 @@ def setup(ti=None, **context):
         "output_collection": context["params"]["frcover_output_collection_id"],
         "sensor": context["params"]["frcover_sensor"],
         "temp_directory": context["params"]["frcover_temp_directory"],
-        "experimental": context["params"]["experimental"],
+        "experimental": context["params"]["frcover_experimental"],
         "input_unity_dapa_client": context["params"]["unity_dapa_client"],
         "input_unity_dapa_api": context["params"]["unity_dapa_api"],
         "input_crid": context["params"]["crid"],

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -1,0 +1,132 @@
+# DAG for executing the SBG L1-to-L2 End-To-End Workflow
+# See https://github.com/unity-sds/sbg-workflows/blob/main/L1-to-L2-e2e.cwl
+import json
+import uuid
+from datetime import datetime
+
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from kubernetes.client import models as k8s
+
+from airflow import DAG
+
+# The Kubernetes Pod that executes the CWL-Docker container
+# Must use elevated privileges to start/stop the Docker engine
+POD_TEMPLATE_FILE = "/opt/airflow/dags/docker_cwl_pod.yaml"
+
+# The Kubernetes namespace within which the Pod is run (it must already exist)
+POD_NAMESPACE = "airflow"
+
+# The path of the working directory where the CWL workflow is executed
+# (aka the starting directory for cwl-runner).
+# This is fixed to the EFS /scratch directory in this DAG.
+WORKING_DIR = "/scratch"
+
+# Default DAG configuration
+dag_default_args = {
+    "owner": "unity-sps",
+    "depends_on_past": False,
+    "start_date": datetime.utcfromtimestamp(0),
+}
+
+INPUT_AUX_STAC = '{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}'
+INPUT_CMR_STAC = "https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z"
+
+DAPA_CLIENT_DEV_VENUE = "40c2s0ulbhp9i0fmaph3su9jch"
+DAPA_API_DEV_VENUE = "https://d3vc8w9zcq658.cloudfront.net"
+OUTPUT_COLLECTION_ID = "urn:nasa:unity:unity:dev:SBG-L1B_PRE___1"
+OUTPUT_DATA_BUCKET = "sps-dev-ds-storage"
+
+dag = DAG(
+    dag_id="sbg-l1-to-l2-e2e-cwl-step-by-step-dag",
+    description="SBG L1 to L2 End-To-End Workflow as step-by-step CWL DAGs",
+    tags=["SBG", "Unity", "SPS", "NASA", "JPL"],
+    is_paused_upon_creation=False,
+    catchup=False,
+    schedule=None,
+    max_active_runs=100,
+    default_args=dag_default_args,
+    params={
+        # For Preprocess step
+        "input_cmr_stac": Param(INPUT_CMR_STAC, type="string"),
+        "input_unity_dapa_client": Param(DAPA_CLIENT_DEV_VENUE, type="string"),
+        "input_unity_dapa_api": Param(DAPA_API_DEV_VENUE, type="string"),
+        "input_crid": Param("001", type="string"),
+        "output_collection_id": Param(OUTPUT_COLLECTION_ID, type="string"),
+        "output_data_bucket": Param(OUTPUT_DATA_BUCKET, type="string")
+
+        # For CMR Search Step
+        # "input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
+        # "input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+        # "input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+
+        # For unity data upload step, unity catalog
+        # "output_preprocess_collection_id": Param("40c2s0ulbhp9i0fmaph3su9jch", type="string"),
+        # "input_aux_stac": Param(INPUT_AUX_STAC, type="string"),
+        # For unity data upload step, unity catalog
+        # "output_isofit_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_RFL___1", type="string"),
+        # "output_resample_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_RSRFL___1", type="string"),
+        # "output_refcorrect_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_CORFL___1", type="string"),
+    },
+)
+
+
+# Task that serializes the job arguments into a JSON string
+def setup(ti=None, **context):
+    task_dict = {
+        "input_processing_labels": ["label1", "label2"],
+        "input_cmr_stac": context["params"]["input_cmr_stac"],
+        "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
+        "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
+        "input_crid": context["params"]["input_crid"],
+        "output_collection_id": context["params"]["output_collection_id"],
+        "output_data_bucket": context["params"]["output_data_bucket"],
+        # "input_cmr_collection_name": context["params"]["input_cmr_collection_name"],
+        # "input_cmr_search_start_time": context["params"]["input_cmr_search_start_time"],
+        ###"input_cmr_search_stop_time": context["params"]["input_cmr_search_stop_time"],
+        # "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
+        # "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
+        # "input_crid": context["params"]["input_crid"],
+        # "output_preprocess_collection_id": context["params"]["output_preprocess_collection_id"],
+        # "output_data_bucket": context["params"]["output_data_bucket"],
+        # "input_aux_stac": context["params"]["input_aux_stac"],
+        # "output_isofit_collection_id": context["params"]["output_isofit_collection_id"],
+        # "output_resample_collection_id": context["params"]["output_resample_collection_id"],
+        # "output_refcorrect_collection_id": context["params"]["output_refcorrect_collection_id"],
+    }
+    ti.xcom_push(key="cwl_args", value=json.dumps(task_dict))
+
+
+setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
+
+# Step: Preprocess
+SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
+preprocess_task = KubernetesPodOperator(
+    namespace=POD_NAMESPACE,
+    name="Preprocess",
+    on_finish_action="delete_pod",
+    hostnetwork=False,
+    startup_timeout_seconds=1000,
+    get_logs=True,
+    task_id="SBG_Preprocess",
+    full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-preprocess-pod-" + uuid.uuid4().hex))),
+    pod_template_file=POD_TEMPLATE_FILE,
+    arguments=[
+        SBG_PREPROCESS_CWL,
+        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}",
+        WORKING_DIR,
+    ],
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+        )
+    ],
+    dag=dag,
+)
+
+setup_task >> preprocess_task

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -64,9 +64,8 @@ dag = DAG(
         "isofit_input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
         "isofit_input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
         "isofit_input_stac": Param(ISOFIT_INPUT_STAC, type="string"),
-
         "isofit_input_aux_stac": Param(ISOFIT_INPUT_AUX_STAC, type="string"),
-        "isofit_isofit_output_collection_id": Param("ISOFIT_OUTPUT_COLLECTION_ID", type="string"),
+        "isofit_output_collection_id": Param("ISOFIT_OUTPUT_COLLECTION_ID", type="string"),
 
         # For all steps
         "input_unity_dapa_client": Param(DAPA_CLIENT_DEV_VENUE, type="string"),
@@ -105,7 +104,7 @@ def setup(ti=None, **context):
         "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
         "input_crid": context["params"]["input_crid"],
         "output_collection_id": context["params"]["isofit_output_collection_id"],
-        "output_data_bucket": context["params"]["isofit_output_collection_id"],
+        "output_data_bucket": context["params"]["output_data_bucket"],
     }
     ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict))
 

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -318,4 +318,6 @@ cleanup_task = PythonOperator(
     dag=dag,
 )
 
-setup_task >> preprocess_task >> resample_task >> reflect_correct_task >> frcover_task >> cleanup_task
+# setup_task >> preprocess_task >> resample_task >> reflect_correct_task >> frcover_task >> cleanup_task
+
+setup_task >> reflect_correct_task >> frcover_task >> cleanup_task

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -33,15 +33,8 @@ dag_default_args = {
     "start_date": datetime.utcfromtimestamp(0),
 }
 
-PREPROCESS_INPUT_AUX_STAC = 'https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z'
-ISOFIT_INPUT_STAC = "https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27"
-ISOFIT_INPUT_AUX_STAC = '{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}'
-ISOFIT_OUTPUT_COLLECTION_ID = "urn:nasa:unity:unity:dev:SBG-L2A_RFL___1"
-
-DAPA_CLIENT_DEV_VENUE = "40c2s0ulbhp9i0fmaph3su9jch"
-DAPA_API_DEV_VENUE = "https://d3vc8w9zcq658.cloudfront.net"
-PREPROCESS_OUTPUT_COLLECTION_ID = "urn:nasa:unity:unity:dev:SBG-L1B_PRE___1"
-OUTPUT_DATA_BUCKET = "sps-dev-ds-storage"
+# common parameters
+INPUT_PROCESSING_LABELS = ["label1", "label2"]
 
 dag = DAG(
     dag_id="sbg-l1-to-l2-e2e-cwl-step-by-step-dag",
@@ -54,32 +47,29 @@ dag = DAG(
     default_args=dag_default_args,
     params={
 
-        # step: CMR
-        "input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
-        "input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-        "input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+        # For step: CMR
+        #"input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
+        #"input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+        #"input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
 
-        # step: PREPROCESS
-        # "preprocess_input_cmr_stac": Param(PREPROCESS_INPUT_AUX_STAC, type="string"),
-        "preprocess_output_collection_id": Param(PREPROCESS_OUTPUT_COLLECTION_ID, type="string"),
+        # For step: PREPROCESS
+        "preprocess_input_cmr_stac": Param("https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z", type="string"),
+        "preprocess_output_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L1B_PRE___1", type="string"),
 
-        # step: PREPROCESS DATA CATALOG
-
-        # step: ISOFIT
-        # "isofit_input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
-        # "isofit_input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-        # "isofit_input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
-        "isofit_input_stac": Param(ISOFIT_INPUT_STAC, type="string"),
-        "isofit_input_aux_stac": Param(ISOFIT_INPUT_AUX_STAC, type="string"),
-        "isofit_output_collection_id": Param(ISOFIT_OUTPUT_COLLECTION_ID, type="string"),
+        # For step: ISOFIT
+        "isofit_input_cmr_collection_name": Param("C2408009906-LPCLOUD", type="string"),
+        "isofit_input_cmr_search_start_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+        "isofit_input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
+        "isofit_input_stac": Param("https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27", type="string"),
+        "isofit_input_aux_stac": Param('{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}', type="string"),
+        "isofit_output_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2A_RFL___1", type="string"),
 
         # For all steps
-        "input_unity_dapa_client": Param(DAPA_CLIENT_DEV_VENUE, type="string"),
-        "input_unity_dapa_api": Param(DAPA_API_DEV_VENUE, type="string"),
-        "output_data_bucket": Param(OUTPUT_DATA_BUCKET, type="string"),
-        "input_crid": Param("001", type="string"),
+        "unity_dapa_client": Param("40c2s0ulbhp9i0fmaph3su9jch", type="string"),
+        "unity_dapa_api": Param("https://d3vc8w9zcq658.cloudfront.net", type="string"),
         "unity_stac_auth": Param("UNITY", type="string"),
-
+        "output_data_bucket": Param("sps-dev-ds-storage", type="string"),
+        "crid": Param("001", type="string"),
     },
 )
 
@@ -88,40 +78,36 @@ dag = DAG(
 # Task that serializes the job arguments into a JSON string
 def setup(ti=None, **context):
 
-    cmr_dict = {
-        "cmr_collection": context["params"]["input_cmr_collection_name"],
-        "cmr_start_time": context["params"]["input_cmr_search_start_time"],
-        "cmr_stop_time": context["params"]["input_cmr_search_stop_time"],
-    }
-    ti.xcom_push(key="cmr_query_args", value=json.dumps(cmr_dict))
+    #cmr_dict = {
+    #    "cmr_collection": context["params"]["input_cmr_collection_name"],
+    #    "cmr_start_time": context["params"]["input_cmr_search_start_time"],
+    #    "cmr_stop_time": context["params"]["input_cmr_search_stop_time"],
+    #}
+    #ti.xcom_push(key="cmr_query_args", value=json.dumps(cmr_dict))
 
     preprocess_dict = {
-        "input_processing_labels": ["label1", "label2"],
-        # Note: must pass the path RELATIVE to te working directory - not the absolute path on the Pod
-        "input_cmr_stac": {
-            "class": "File",
-            "path": "cmr-results.json",
-        },
-        "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
-        "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
-        "input_crid": context["params"]["input_crid"],
+        "input_processing_labels": INPUT_PROCESSING_LABELS,
+        "input_cmr_stac": context["params"]["preprocess_input_cmr_stac"],
         "output_collection_id": context["params"]["preprocess_output_collection_id"],
+        "input_unity_dapa_client": context["params"]["unity_dapa_client"],
+        "input_unity_dapa_api": context["params"]["unity_dapa_api"],
+        "input_crid": context["params"]["crid"],
         "output_data_bucket": context["params"]["output_data_bucket"],
     }
     ti.xcom_push(key="preprocess_args", value=json.dumps(preprocess_dict))
 
     isofit_dict = {
-        "input_processing_labels": ["label1", "label2"],
-        "input_cmr_collection_name": context["params"]["input_cmr_collection_name"],
-        "input_cmr_search_start_time": context["params"]["input_cmr_search_start_time"],
-        "input_cmr_search_stop_time": context["params"]["input_cmr_search_stop_time"],
+        "input_processing_labels": INPUT_PROCESSING_LABELS,
+        "input_cmr_collection_name": context["params"]["isofit_input_cmr_collection_name"],
+        "input_cmr_search_start_time": context["params"]["isofit_input_cmr_search_start_time"],
+        "input_cmr_search_stop_time": context["params"]["isofit_input_cmr_search_stop_time"],
         "input_stac": context["params"]["isofit_input_stac"],
-        "unity_stac_auth": context["params"]["unity_stac_auth"],
         "input_aux_stac": context["params"]["isofit_input_aux_stac"],
-        "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
-        "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
-        "input_crid": context["params"]["input_crid"],
         "output_collection_id": context["params"]["isofit_output_collection_id"],
+        "unity_stac_auth": context["params"]["unity_stac_auth"],
+        "input_unity_dapa_client": context["params"]["unity_dapa_client"],
+        "input_unity_dapa_api": context["params"]["unity_dapa_api"],
+        "input_crid": context["params"]["crid"],
         "output_data_bucket": context["params"]["output_data_bucket"],
     }
     ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict))
@@ -129,6 +115,7 @@ def setup(ti=None, **context):
 
 setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
 
+'''
 # Step: CMR
 SBG_CMR_WORKFLOW = "http://awslbdockstorestack-lb-1429770210.us-west-2.elb.amazonaws.com:9998/api/ga4gh/trs/v2/tools/%23workflow%2Fdockstore.org%2Fmike-gangl%2Fcmr-trial/versions/4/PLAIN-CWL/descriptor/%2FDockstore.cwl"
 cmr_task = KubernetesPodOperator(
@@ -158,10 +145,10 @@ cmr_task = KubernetesPodOperator(
     # do_xcom_push=True,
     dag=dag,
 )
+'''
 
 # Step: PREPROCESS
-# SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
-SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/LucaCinquini/sbg-workflows/devel/preprocess/sbg-preprocess-workflow.cwl"
+SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
 preprocess_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Preprocess",
@@ -227,6 +214,7 @@ def cleanup(**context):
     else:
         print(f"Directory does not exist, no need to delete: {local_dir}")
 
+
 # The cleanup task will run as long as at lest the Setup task succeeds
 cleanup_task = PythonOperator(
     task_id="Cleanup",
@@ -235,4 +223,4 @@ cleanup_task = PythonOperator(
     dag=dag,
 )
 
-setup_task >> cmr_task >> preprocess_task >> isofit_task >> cleanup_task
+setup_task >> preprocess_task >> isofit_task >> cleanup_task

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -97,6 +97,7 @@ def setup(ti=None, **context):
 
     preprocess_dict = {
         "input_processing_labels": ["label1", "label2"],
+        # Note: must pass the path RELATIVE to te working directory - not the absolute path on the Pod
         "input_cmr_stac": "cmr-results.json",
         "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
         "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
@@ -151,11 +152,13 @@ cmr_task = KubernetesPodOperator(
             persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
         )
     ],
+    # do_xcom_push=True,
     dag=dag,
 )
 
 # Step: PREPROCESS
-SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
+# SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
+SBG_PREPROCESS_CWL = "https://raw.githubusercontent.com/LucaCinquini/sbg-workflows/devel/preprocess/sbg-preprocess-workflow.cwl"
 preprocess_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
     name="Preprocess",

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -179,6 +179,7 @@ preprocess_task = KubernetesPodOperator(
 )
 
 # Step: ISOFIT
+'''
 SBG_ISOFIT_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/isofit/sbg-isofit-workflow.cwl"
 isofit_task = KubernetesPodOperator(
     namespace=POD_NAMESPACE,
@@ -206,6 +207,7 @@ isofit_task = KubernetesPodOperator(
     ],
     dag=dag,
 )
+'''
 
 # Step: RESAMPLE
 SBG_RESAMPLE_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/resample/sbg-resample-workflow.cwl"
@@ -237,6 +239,66 @@ resample_task = KubernetesPodOperator(
     dag=dag,
 )
 
+# Step: REFLECT-CORRECT
+SBG_REFLECT_CORRECT_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/reflect-correct/sbg-reflect-correct-workflow.cwl"
+SBG_REFLECT_CORRECT_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/reflect-correct/sbg-reflect-correct-workflow.dev.yml"
+reflect_correct_task = KubernetesPodOperator(
+    namespace=POD_NAMESPACE,
+    name="Reflect_Correct",
+    on_finish_action="delete_pod",
+    hostnetwork=False,
+    startup_timeout_seconds=1000,
+    get_logs=True,
+    task_id="SBG_Reflect_Correct",
+    full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-reflect-correct-pod-" + uuid.uuid4().hex))),
+    pod_template_file=POD_TEMPLATE_FILE,
+    arguments=[
+        SBG_REFLECT_CORRECT_CWL,
+        SBG_REFLECT_CORRECT_ARGS,
+        WORKING_DIR,
+    ],
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+        )
+    ],
+    dag=dag,
+)
+
+
+# Step: FRCOVER
+SBG_FRCOVER_CWL = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/frcover/sbg-frcover-workflow.cwl"
+SBG_FRCOVER_ARGS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/frcover/sbg-frcover-workflow.dev.yml"
+frcover_task = KubernetesPodOperator(
+    namespace=POD_NAMESPACE,
+    name="Frcover",
+    on_finish_action="delete_pod",
+    hostnetwork=False,
+    startup_timeout_seconds=1000,
+    get_logs=True,
+    task_id="SBG_Frcover",
+    full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-frcover-pod-" + uuid.uuid4().hex))),
+    pod_template_file=POD_TEMPLATE_FILE,
+    arguments=[
+        SBG_FRCOVER_CWL,
+        SBG_FRCOVER_ARGS,
+        WORKING_DIR,
+    ],
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+        )
+    ],
+    dag=dag,
+)
 
 def cleanup(**context):
     dag_run_id = context["dag_run"].run_id
@@ -256,4 +318,4 @@ cleanup_task = PythonOperator(
     dag=dag,
 )
 
-setup_task >> preprocess_task >> resample_task >> cleanup_task
+setup_task >> preprocess_task >> resample_task >> reflect_correct_task >> frcover_task >> cleanup_task

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -132,8 +132,7 @@ cmr_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_CMR_WORKFLOW,
-        "{{ti.xcom_pull(task_ids='Setup', key='cmr_query_args')}}",
-        WORKING_DIR,
+        "{{ti.xcom_pull(task_ids='Setup', key='cmr_query_args')}}"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -191,8 +190,7 @@ isofit_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_ISOFIT_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='isofit_args')}}",
-        WORKING_DIR,
+        "{{ti.xcom_pull(task_ids='Setup', key='isofit_args')}}"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -27,9 +27,10 @@ POD_NAMESPACE = "airflow"
 WORKING_DIR = "/scratch"
 
 # Resources needed by each Task
+# EC2 r6a.xlarge	4vCPU	32GiB
 CONTAINER_RESOURCES = k8s.V1ResourceRequirements(
-        limits={"memory": "250M", "cpu": "100m", "ephemeral-storage": "20G"},
-        requests={"ephemeral-storage": "50G"}
+        limits={"memory": "4Gi", "cpu": "500m", "ephemeral-storage": "50G"},
+        requests={"memory": "2Gi", "cpu": "250m", "ephemeral-storage": "25G"}
 )
 
 # Default DAG configuration

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -37,29 +37,28 @@ dag_default_args = {
 INPUT_PROCESSING_LABELS = ["label1", "label2"]
 
 class CwlKubernetesPodOperator(KubernetesPodOperator):
-    def __init__(self, name, task_id, arguments, dag, dag_run_id):
-        super(KubernetesPodOperator, self).__init__(
-            namespace=POD_NAMESPACE,
-            name=name,
-            on_finish_action="delete_pod",
-            hostnetwork=False,
-            startup_timeout_seconds=1000,
-            get_logs=True,
-            task_id=task_id,
-            full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=(task_id.lower()+"-pod-" + uuid.uuid4().hex))),
-            pod_template_file=POD_TEMPLATE_FILE,
-            arguments=arguments,
-            volume_mounts=[
+    def __init__(self, name, task_id, arguments, dag, dag_run_id, **kwargs):
+        super().__init__(**kwargs)
+        self.namespace = POD_NAMESPACE
+        self.name = name
+        self.on_finish_action = "delete_pod",
+        self.hostnetwork=False
+        self.startup_timeout_seconds = 1000,
+        self.get_logs = True
+        self.task_id = task_id
+        self.full_pod_spec = k8s.V1Pod(k8s.V1ObjectMeta(name=(task_id.lower()+"-pod-" + uuid.uuid4().hex))),
+        self.pod_template_file = POD_TEMPLATE_FILE,
+        self.arguments = arguments
+        self.volume_mounts=[
                 k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path=dag_run_id)
             ],
-            volumes=[
+        self.volumes=[
                 k8s.V1Volume(
                     name="workers-volume",
                     persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
                 )
             ],
-            dag=dag,
-        )
+        self.dag=dag
 
 
 sbg_dag = DAG(

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -29,7 +29,7 @@ WORKING_DIR = "/scratch"
 # Resources needed by each Task
 CONTAINER_RESOURCES = k8s.V1ResourceRequirements(
         limits={"memory": "250M", "cpu": "100m", "ephemeral-storage": "20G"},
-        requests={"ephemeral-storage": "20G"}
+        requests={"ephemeral-storage": "50G"}
 )
 
 # Default DAG configuration
@@ -109,7 +109,12 @@ def setup(ti=None, **context):
         "input_cmr_stac": context["params"]["preprocess_input_cmr_stac"],
         "output_collection_id": context["params"]["preprocess_output_collection_id"],
         "input_crid": context["params"]["crid"],
-    } | venue_dict
+        "input_unity_dapa_client": context["params"]["unity_dapa_client"],
+        "input_unity_dapa_api": context["params"]["unity_dapa_api"],
+        "output_data_bucket": context["params"]["output_data_bucket"],
+    }
+    # FIXME
+    # } | venue_dict
     ti.xcom_push(key="preprocess_args", value=json.dumps(preprocess_dict))
 
     isofit_dict = {
@@ -173,7 +178,8 @@ preprocess_task = KubernetesPodOperator(
     task_id="SBG_Preprocess",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-preprocess-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    container_resources=CONTAINER_RESOURCES,
+    # FIXME
+    # container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_PREPROCESS_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='preprocess_args')}}"

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -33,8 +33,7 @@ dag_default_args = {
     "start_date": datetime.utcfromtimestamp(0),
 }
 
-PREPROCESS_INPUT_AUX_STAC = '{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}'
-
+PREPROCESS_INPUT_AUX_STAC = 'https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z'
 ISOFIT_INPUT_STAC = "https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27"
 ISOFIT_INPUT_AUX_STAC = '{"numberMatched":{"total_size":1},"numberReturned":1,"stac_version":"1.0.0","type":"FeatureCollection","links":[{"rel":"self","href":"https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L1B_PRE___1/items?limit=10"},{"rel":"root","href":"https://d3vc8w9zcq658.cloudfront.net"}],"features":[{"type":"Feature","stac_version":"1.0.0","id":"urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120","properties":{"datetime":"2024-02-14T22:04:41.078000Z","start_datetime":"2024-01-03T13:19:36Z","end_datetime":"2024-01-03T13:19:48Z","created":"2024-01-03T13:19:36Z","updated":"2024-02-14T22:05:25.248000Z","status":"completed","provider":"unity"},"geometry":{"type":"Point","coordinates":[0,0]},"links":[{"rel":"collection","href":"."}],"assets":{"sRTMnet_v120.h5":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120.h5","title":"sRTMnet_v120.h5","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]},"sRTMnet_v120_aux.npz":{"href":"s3://sps-dev-ds-storage/urn:nasa:unity:unity:dev:SBG-AUX___1/urn:nasa:unity:unity:dev:SBG-AUX___1:sRTMnet_v120.h5/sRTMnet_v120_aux.npz","title":"sRTMnet_v120_aux.npz","description":"size=-1;checksumType=md5;checksum=unknown;","roles":["data"]}},"bbox":[-180,-90,180,90],"stac_extensions":[],"collection":"urn:nasa:unity:unity:dev:SBG-AUX___1"}]}'
 ISOFIT_OUTPUT_COLLECTION_ID = "urn:nasa:unity:unity:dev:SBG-L2A_RFL___1"
@@ -65,7 +64,7 @@ dag = DAG(
         "isofit_input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
         "isofit_input_stac": Param(ISOFIT_INPUT_STAC, type="string"),
         "isofit_input_aux_stac": Param(ISOFIT_INPUT_AUX_STAC, type="string"),
-        "isofit_output_collection_id": Param("ISOFIT_OUTPUT_COLLECTION_ID", type="string"),
+        "isofit_output_collection_id": Param(ISOFIT_OUTPUT_COLLECTION_ID, type="string"),
 
         # For all steps
         "input_unity_dapa_client": Param(DAPA_CLIENT_DEV_VENUE, type="string"),
@@ -178,11 +177,11 @@ def cleanup(**context):
     else:
         print(f"Directory does not exist, no need to delete: {local_dir}")
 
-
+# The cleanup task will run as long as at lest the Setup task succeeds
 cleanup_task = PythonOperator(
     task_id="Cleanup",
     python_callable=cleanup,
-    trigger_rule=TriggerRule.ALWAYS,
+    trigger_rule=TriggerRule.ONE_SUCCESS,
     dag=dag,
 )
 

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -81,11 +81,14 @@ dag = DAG(
         "frcover_experimental": Param("False", type="string"),
 
         # For all steps
+        "crid": Param("001", type="string"),
+
+        # Unity venue-dependent parameters
+        # These values should be retrieved from SSM
         "unity_dapa_client": Param("40c2s0ulbhp9i0fmaph3su9jch", type="string"),
         "unity_dapa_api": Param("https://d3vc8w9zcq658.cloudfront.net", type="string"),
         "unity_stac_auth": Param("UNITY", type="string"),
         "output_data_bucket": Param("sps-dev-ds-storage", type="string"),
-        "crid": Param("001", type="string"),
     },
 )
 
@@ -132,7 +135,7 @@ def setup(ti=None, **context):
         "output_collection_id": context["params"]["isofit_output_collection_id"],
         "unity_stac_auth": context["params"]["unity_stac_auth"],
         "input_crid": context["params"]["crid"],
-    } | venue_dict
+    }.update(venue_dict)
     ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict))
 
     resample_dict = {
@@ -209,7 +212,7 @@ isofit_task = KubernetesPodOperator(
     task_id="SBG_Isofit",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-isofit-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    container_resources=CONTAINER_RESOURCES,
+    # container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_ISOFIT_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='isofit_args')}}"

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -163,8 +163,7 @@ preprocess_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_PREPROCESS_CWL,
-        "{{ti.xcom_pull(task_ids='Setup', key='preprocess_args')}}",
-        WORKING_DIR,
+        "{{ti.xcom_pull(task_ids='Setup', key='preprocess_args')}}"
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -222,8 +221,7 @@ resample_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_RESAMPLE_CWL,
-        SBG_RESAMPLE_ARGS,
-        WORKING_DIR,
+        SBG_RESAMPLE_ARGS
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -252,8 +250,7 @@ reflect_correct_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_REFLECT_CORRECT_CWL,
-        SBG_REFLECT_CORRECT_ARGS,
-        WORKING_DIR,
+        SBG_REFLECT_CORRECT_ARGS
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
@@ -283,8 +280,7 @@ frcover_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         SBG_FRCOVER_CWL,
-        SBG_FRCOVER_ARGS,
-        WORKING_DIR,
+        SBG_FRCOVER_ARGS
     ],
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -97,7 +97,7 @@ def setup(ti=None, **context):
 
     preprocess_dict = {
         "input_processing_labels": ["label1", "label2"],
-        "input_cmr_stac": "/scratch/cmr-results.json",
+        "input_cmr_stac": "cmr-results.json",
         "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
         "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
         "input_crid": context["params"]["input_crid"],

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -138,7 +138,8 @@ def setup(ti=None, **context):
         "unity_stac_auth": context["params"]["unity_stac_auth"],
         "input_crid": context["params"]["crid"],
     }
-    ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict.update(venue_dict)))
+    isofit_dict.update(venue_dict)
+    ti.xcom_push(key="isofit_args", value=json.dumps(isofit_dict))
 
     resample_dict = {
         "input_stac": context["params"]["resample_input_stac"],

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -229,4 +229,4 @@ cleanup_task = PythonOperator(
     dag=dag,
 )
 
-setup_task >> preprocess_task >> isofit_task >> cleanup_task
+setup_task >> cmr_task >> preprocess_task >> isofit_task >> cleanup_task

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -60,7 +60,7 @@ dag = DAG(
         "input_cmr_search_stop_time": Param("2024-01-03T13:19:36.000Z", type="string"),
 
         # step: PREPROCESS
-        "preprocess_input_cmr_stac": Param(PREPROCESS_INPUT_AUX_STAC, type="string"),
+        # "preprocess_input_cmr_stac": Param(PREPROCESS_INPUT_AUX_STAC, type="string"),
         "preprocess_output_collection_id": Param(PREPROCESS_OUTPUT_COLLECTION_ID, type="string"),
 
         # step: PREPROCESS DATA CATALOG
@@ -97,7 +97,7 @@ def setup(ti=None, **context):
 
     preprocess_dict = {
         "input_processing_labels": ["label1", "label2"],
-        "input_cmr_stac": context["params"]["preprocess_input_cmr_stac"],
+        "input_cmr_stac": "/scratch/cmr-results.json",
         "input_unity_dapa_client": context["params"]["input_unity_dapa_client"],
         "input_unity_dapa_api": context["params"]["input_unity_dapa_api"],
         "input_crid": context["params"]["input_crid"],

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -184,7 +184,7 @@ preprocess_task = KubernetesPodOperator(
     task_id="SBG_Preprocess",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-preprocess-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    container_resources=CONTAINER_RESOURCES,
+    # container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_PREPROCESS_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='preprocess_args')}}"
@@ -214,7 +214,7 @@ isofit_task = KubernetesPodOperator(
     task_id="SBG_Isofit",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-isofit-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    container_resources=CONTAINER_RESOURCES,
+    # container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_ISOFIT_CWL,
         "{{ti.xcom_pull(task_ids='Setup', key='isofit_args')}}"
@@ -244,7 +244,7 @@ resample_task = KubernetesPodOperator(
     task_id="SBG_Resample",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-resample-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    container_resources=CONTAINER_RESOURCES,
+    # container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_RESAMPLE_CWL,
         # SBG_RESAMPLE_ARGS
@@ -275,7 +275,7 @@ reflect_correct_task = KubernetesPodOperator(
     task_id="SBG_Reflect_Correct",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-reflect-correct-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    container_resources=CONTAINER_RESOURCES,
+    # container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_REFLECT_CORRECT_CWL,
         # SBG_REFLECT_CORRECT_ARGS
@@ -307,7 +307,7 @@ frcover_task = KubernetesPodOperator(
     task_id="SBG_Frcover",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-frcover-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    container_resources=CONTAINER_RESOURCES,
+    # container_resources=CONTAINER_RESOURCES,
     arguments=[
         SBG_FRCOVER_CWL,
         # SBG_FRCOVER_ARGS

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -68,7 +68,7 @@ dag = DAG(
         # For step: FRCOVER
         "frcover_input_stac": Param("https://d3vc8w9zcq658.cloudfront.net/am-uds-dapa/collections/urn:nasa:unity:unity:dev:SBG-L2A_CORFL___1/items?filter=start_datetime%20%3E%3D%20%272024-01-03T13%3A19%3A34Z%27%20AND%20start_datetime%20%3C%3D%20%272024-01-03T13%3A19%3A36Z%27", type="string"),
         "frcover_output_collection_id": Param("urn:nasa:unity:unity:dev:SBG-L2B_FRCOV___1", type="string"),
-        "frcover_sensor": Param("EMIT", type="sting"),
+        "frcover_sensor": Param("EMIT", type="string"),
         "frcover_temp_directory": Param("/tmp", type="string"),
         "frcover_experimental": Param("False", type="string"),
 

--- a/airflow/dags/sbg_preprocess_cwl_dag.py
+++ b/airflow/dags/sbg_preprocess_cwl_dag.py
@@ -90,10 +90,7 @@ cwl_task = KubernetesPodOperator(
     task_id="SBG_Preprocess_CWL",
     full_pod_spec=k8s.V1Pod(k8s.V1ObjectMeta(name=("sbg-preprocess-cwl-pod-" + uuid.uuid4().hex))),
     pod_template_file=POD_TEMPLATE_FILE,
-    arguments=[
-        "{{ params.cwl_workflow }}",
-        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}"
-    ],
+    arguments=["{{ params.cwl_workflow }}", "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}"],
     dag=dag,
     volume_mounts=[
         k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")

--- a/airflow/dags/sbg_preprocess_cwl_dag.py
+++ b/airflow/dags/sbg_preprocess_cwl_dag.py
@@ -92,8 +92,7 @@ cwl_task = KubernetesPodOperator(
     pod_template_file=POD_TEMPLATE_FILE,
     arguments=[
         "{{ params.cwl_workflow }}",
-        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}",
-        WORKING_DIR,
+        "{{ti.xcom_pull(task_ids='Setup', key='cwl_args')}}"
     ],
     dag=dag,
     volume_mounts=[

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -47,7 +47,7 @@ done
 . /usr/share/cwl/venv/bin/activate
 pwd
 ls -lR
-cwl-runner --tmp-outdir-prefix "$PWD"/ "$cwl_workflow" "$job_args"
+cwl-runner --tmp-outdir-prefix "$PWD"/ --no-read-only "$cwl_workflow" "$job_args"
 ls -lR
 deactivate
 

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -49,6 +49,9 @@ pwd
 ls -lR
 cwl-runner --tmp-outdir-prefix "$PWD"/ --no-read-only "$cwl_workflow" "$job_args"
 ls -lR
+# FIXME
+# mkdir -p /airflow/xcom/
+# cp cmr-results.json /airflow/xcom/return.json
 deactivate
 
 # Stop Docker engine

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -16,7 +16,7 @@ WORKING_DIR="/scratch"
 set -ex
 cwl_workflow=$1
 job_args=$2
-json_output=${3:""}
+json_output=$3
 
 # create working directory if it doesn't exist
 mkdir -p "$WORKING_DIR"

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -7,17 +7,20 @@
 #        (example: { "name": "John Doe" })
 #  OR b) The URL of a YAML or JSON file containing the job parameters
 #        (example: https://github.com/unity-sds/sbg-workflows/blob/main/L1-to-L2-e2e.dev.yml)
-# $3: optional working directory, defaults to the current directory
-# Note: The working must be accessible by the Docker container that executes this script
+# $3: optional path to an output JSON file that needs to be shared as Airflow "xcom" data
+
+# Must be the same as the path of the Persistent Volume mounted by the Airflow KubernetesPodOperator
+# that executes this script
+WORKING_DIR="/scratch"
 
 set -ex
 cwl_workflow=$1
 job_args=$2
-work_dir=${3:-.}
+json_output=${3:""}
 
 # create working directory if it doesn't exist
-mkdir -p "$work_dir"
-cd $work_dir
+mkdir -p "$WORKING_DIR"
+cd $WORKING_DIR
 
 # switch between the 2 cases a) and b) for job_args
 # remove arguments from previous tasks
@@ -32,7 +35,8 @@ else
   echo "Using job arguments from JSON string:" && cat ./job_args.json
   job_args="./job_args.json"
 fi
-echo "Executing the CWL workflow: $cwl_workflow with json arguments: $job_args and working directory: $work_dir"
+echo "Executing the CWL workflow: $cwl_workflow with json arguments: $job_args and working directory: $WORKING_DIR"
+echo "JSON XCOM output: ${json_output}"
 
 # Start Docker engine
 dockerd &> dockerd-logfile &
@@ -52,9 +56,13 @@ ls -lR
 cwl-runner --tmp-outdir-prefix "$PWD"/ --no-read-only "$cwl_workflow" "$job_args"
 ls -lR
 
-# FIXME
-mkdir -p /airflow/xcom/
-echo "\"A new message in json format\"" > /airflow/xcom/return.json
+# Optionally, save the requested output file to a location
+# where it will be picked up by the Airflow XCOM mechanism
+# Note: the content of the file MUST be valid JSON or XCOM will fail.
+if [ ! -z "${json_output}" -a "${json_output}" != " " ]; then
+  mkdir -p /airflow/xcom/
+  cp ${json_output} /airflow/xcom/return.json
+fi
 
 deactivate
 

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -46,6 +46,7 @@ done
 # List contents when done
 . /usr/share/cwl/venv/bin/activate
 pwd
+ls -lR
 cwl-runner --tmp-outdir-prefix "$PWD"/ "$cwl_workflow" "$job_args"
 ls -lR
 deactivate

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -51,9 +51,11 @@ pwd
 ls -lR
 cwl-runner --tmp-outdir-prefix "$PWD"/ --no-read-only "$cwl_workflow" "$job_args"
 ls -lR
+
 # FIXME
-# mkdir -p /airflow/xcom/
-# cp cmr-results.json /airflow/xcom/return.json
+mkdir -p /airflow/xcom/
+echo "\"A new message in json format\"" > /airflow/xcom/return.json
+
 deactivate
 
 # Stop Docker engine

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -15,22 +15,24 @@ cwl_workflow=$1
 job_args=$2
 work_dir=${3:-.}
 
+# create working directory if it doesn't exist
+mkdir -p "$work_dir"
+cd $work_dir
+
 # switch between the 2 cases a) and b) for job_args
+# remove arguments from previous tasks
+rm -f ./job_args.json
 if [ "$job_args" = "${job_args#{}" ]
 then
   # job_args does NOT start with '{'
   echo "Using job arguments from URL: $job_args"
 else
   # job_args starts with '{'
-  echo "$job_args" > /tmp/job_args.json
-  echo "Using job arguments from JSON string:" && cat /tmp/job_args.json
-  job_args="/tmp/job_args.json"
+  echo "$job_args" > ./job_args.json
+  echo "Using job arguments from JSON string:" && cat ./job_args.json
+  job_args="./job_args.json"
 fi
 echo "Executing the CWL workflow: $cwl_workflow with json arguments: $job_args and working directory: $work_dir"
-
-# create working directory if it doesn't exist
-mkdir -p "$work_dir"
-cd $work_dir
 
 # Start Docker engine
 dockerd &> dockerd-logfile &

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -236,7 +236,9 @@ resource "aws_iam_policy" "airflow_worker_policy" {
             "ecr:GetDownloadUrlForLayer",
             "ecr:BatchGetImage",
             "secretsmanager:GetSecretValue",
-            "ssm:GetParameters"
+            "ssm:GetParameters",
+            "ssm:DescribeParameters",
+            "ssm:GetParameter"
           ],
           "Resource" : "*"
         }


### PR DESCRIPTION
## Purpose

This PR adds functionality that enables executing SBG workflows as independent Airflow Tasks that execute independent CWL documents.

## Proposed Changes

- [ADD] The "busybox" DAG that can be used to test the sharing of data between Tasks that execute a CWL workflow which includes a Docker invocation.
- [ADD] The "sbg-l1-to-l2-e2e-cwl-step-by-step-dag" DAG that executes the SBG end-to-end workflow as separate CWL documents
- [CHANGE] The "docker_cwl.sh" script has been changed to support the additional capability to push the content of a given file to Xcom. This parameter replaces the previous parameter used to change the working directory, which was not really useful.
- [ADD] IAM permission to retrieve SSM parameters from within the KubernetesPodOperator. This will be used to retrieve the venue-dependent parameters from SSM instead of hard-coding them in the DAGs.

## Issues

- https://github.com/unity-sds/unity-sps/issues/21

## Testing

- The following DAGs have been completed successfully with the code in this branch:
- Busybox
- SBG end-to-end step-by-step (with inputs from the Airflow UI)
- CWL Dag executing the SBG pre-process CWL workflow
- SBG pre-process single CWL DAG (with inputs from the Airflow UI) 
- SBG end-to-end single CWL DAG (with inputs from the Airflow UI)
