### PR TITLE
63 dags pv

### DIFF
--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -85,7 +85,7 @@ echo_message_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,
@@ -114,7 +114,7 @@ cat_file_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,
@@ -139,7 +139,7 @@ echo_xcom_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,

--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -103,7 +103,7 @@ cwl_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
 )

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -209,7 +209,7 @@ preprocess_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,
@@ -240,7 +240,7 @@ isofit_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,
@@ -275,7 +275,7 @@ resample_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,
@@ -308,7 +308,7 @@ reflect_correct_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,
@@ -344,7 +344,7 @@ frcover_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
     dag=dag,

--- a/airflow/dags/sbg_preprocess_cwl_dag.py
+++ b/airflow/dags/sbg_preprocess_cwl_dag.py
@@ -98,7 +98,7 @@ cwl_task = KubernetesPodOperator(
     volumes=[
         k8s.V1Volume(
             name="workers-volume",
-            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="kpo-efs"),
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
         )
     ],
 )

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -440,7 +440,7 @@ resource "kubernetes_config_map" "airflow_dags" {
   }
 
   data = {
-    for f in fileset("${path.module}/../../../airflow/dags", "*.py") :
+    for f in fileset("${path.module}/../../../airflow/dags", "*.{py,yaml}") :
     f => file(join("/", ["${path.module}/../../../airflow/dags", f]))
   }
 }


### PR DESCRIPTION
## Purpose

- This PR is needed to make sure the DAGs that rely on the CWL Pod can still run to completion.

## Proposed Changes

- [FIX] At deployment time, must copy both the .py and the .yaml files to the DAGs folder on the shared PV
- [FIX] Must replace the old PV name "kpo-efs" with the new name "airflow-kpo"

## Issues

- https://github.com/unity-sds/unity-sps/issues/63

## Testing

- After the fix, the "busybox" and "sbg-e2e-step-by-step" could run to completion.
