### PR TITLE
Add deployment variables to Airflow environment

### DIFF
--- a/airflow/dags/env_test.py
+++ b/airflow/dags/env_test.py
@@ -26,14 +26,12 @@ dump_env = BashOperator(
 
 check_vars = BashOperator(
     task_id="check",
-    bash_command=format(
-        "echo %s %s %s %s %s",
+    bash_command="echo {} {} {} {} {}".format(
         Variable.get("unity_project"),
         Variable.get("unity_venue"),
         Variable.get("unity_deployment_name"),
         Variable.get("unity_counter"),
-        Variable.get("unity_cluster_name"),
-    ),
+        Variable.get("unity_cluster_name")),
 )
 
 

--- a/airflow/dags/env_test.py
+++ b/airflow/dags/env_test.py
@@ -37,6 +37,7 @@ with DAG(
             Variable.get("unity_venue"),
             Variable.get("unity_deployment_name"),
             Variable.get("unity_counter"),
-            Variable.get("unity_cluster_name")),
+            Variable.get("unity_cluster_name"),
+        ),
     )
     dump_env >> check_vars

--- a/airflow/dags/env_test.py
+++ b/airflow/dags/env_test.py
@@ -18,29 +18,25 @@ default_args = {
     "start_date": datetime.utcfromtimestamp(0),
 }
 
-
-dump_env = BashOperator(
-    task_id="env",
-    bash_command="env",
-)
-
-check_vars = BashOperator(
-    task_id="check",
-    bash_command="echo {} {} {} {} {}".format(
-        Variable.get("unity_project"),
-        Variable.get("unity_venue"),
-        Variable.get("unity_deployment_name"),
-        Variable.get("unity_counter"),
-        Variable.get("unity_cluster_name")),
-)
-
-
-dag = DAG(
+with DAG(
     dag_id="env_test",
     default_args=default_args,
     schedule=None,
     is_paused_upon_creation=False,
     tags=["test"],
-)
+) as dag:
+    dump_env = BashOperator(
+        task_id="env",
+        bash_command="env",
+    )
 
-dump_env > check_vars
+    check_vars = BashOperator(
+        task_id="check",
+        bash_command="echo {} {} {} {} {}".format(
+            Variable.get("unity_project"),
+            Variable.get("unity_venue"),
+            Variable.get("unity_deployment_name"),
+            Variable.get("unity_counter"),
+            Variable.get("unity_cluster_name")),
+    )
+    dump_env >> check_vars

--- a/airflow/dags/env_test.py
+++ b/airflow/dags/env_test.py
@@ -1,0 +1,48 @@
+"""
+# DAG Name: Env Test
+
+# Purpose
+
+# Usage
+"""  # noqa: E501
+
+from datetime import datetime
+
+from airflow.models import Variable
+from airflow.operators.bash import BashOperator
+
+from airflow import DAG
+
+default_args = {
+    "owner": "unity-sps",
+    "start_date": datetime.utcfromtimestamp(0),
+}
+
+
+dump_env = BashOperator(
+    task_id="env",
+    bash_command="env",
+)
+
+check_vars = BashOperator(
+    task_id="check",
+    bash_command=format(
+        "echo %s %s %s %s %s",
+        Variable.get("unity_project"),
+        Variable.get("venue"),
+        Variable.get("deployment_name"),
+        Variable.get("counter"),
+        Variable.get("cluster_name"),
+    ),
+)
+
+
+dag = DAG(
+    dag_id="env_test",
+    default_args=default_args,
+    schedule=None,
+    is_paused_upon_creation=False,
+    tags=["test"],
+)
+
+dump_env > check_vars

--- a/airflow/dags/env_test.py
+++ b/airflow/dags/env_test.py
@@ -29,10 +29,10 @@ check_vars = BashOperator(
     bash_command=format(
         "echo %s %s %s %s %s",
         Variable.get("unity_project"),
-        Variable.get("venue"),
-        Variable.get("deployment_name"),
-        Variable.get("counter"),
-        Variable.get("cluster_name"),
+        Variable.get("unity_venue"),
+        Variable.get("unity_deployment_name"),
+        Variable.get("unity_counter"),
+        Variable.get("unity_cluster_name"),
     ),
 )
 

--- a/airflow/helm/values.tmpl.yaml
+++ b/airflow/helm/values.tmpl.yaml
@@ -261,6 +261,16 @@ dags:
 env:
   - name: "AIRFLOW_VAR_KUBERNETES_PIPELINE_NAMESPACE"
     value: "${kubernetes_namespace}"
+  - name: "UNITY_PROJECT"
+    value: "${unity_project}"
+  - name: "UNITY_VENUE"
+    value: "${unity_venue}"
+  - name: "UNITY_DEPLOYMENT_NAME"
+    value: "${unity_deployment_name}"
+  - name: "UNITY_COUNTER"
+    value: "${unity_counter}"
+  - name: "UNITY_CLUSTER_NAME"
+    value: "${unity_cluster_name}"
 
 # https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/security/api.html
 extraEnv: |

--- a/airflow/helm/values.tmpl.yaml
+++ b/airflow/helm/values.tmpl.yaml
@@ -261,15 +261,15 @@ dags:
 env:
   - name: "AIRFLOW_VAR_KUBERNETES_PIPELINE_NAMESPACE"
     value: "${kubernetes_namespace}"
-  - name: "UNITY_PROJECT"
+  - name: "AIRFLOW_VAR_UNITY_PROJECT"
     value: "${unity_project}"
-  - name: "UNITY_VENUE"
+  - name: "AIRFLOW_VAR_UNITY_VENUE"
     value: "${unity_venue}"
-  - name: "UNITY_DEPLOYMENT_NAME"
+  - name: "AIRFLOW_VAR_UNITY_DEPLOYMENT_NAME"
     value: "${unity_deployment_name}"
-  - name: "UNITY_COUNTER"
+  - name: "AIRFLOW_VAR_UNITY_COUNTER"
     value: "${unity_counter}"
-  - name: "UNITY_CLUSTER_NAME"
+  - name: "AIRFLOW_VAR_UNITY_CLUSTER_NAME"
     value: "${unity_cluster_name}"
 
 # https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/security/api.html

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -510,6 +510,11 @@ resource "helm_release" "airflow" {
       webserver_navbar_color   = local.airflow_webserver_navbar_color
       service_area             = upper(var.service_area)
       service_area_version     = var.release
+      unity_project            = var.project
+      unity_venue              = var.venue
+      unity_deployment_name    = var.deployment_name
+      unity_counter            = var.counter
+      unity_cluster_name       = data.aws_eks_cluster.cluster.name
     })
   ]
   set_sensitive {


### PR DESCRIPTION
## Purpose

- Make relevant Unity environment variables available in the SPS Airflow deployment

## Proposed Changes

- ADD unity environment variables (project, venue, deployment name, counter, cluster name) to Airflow container environment
- ADD simple environment printing DAG (only for testing, removable)

## Issues

- unity-sds/unity-sps#85

## Testing

- Tested with manual cluster
- Used new env_test dag to expose available variables (not visible in Airflow UI)
<img width="1271" alt="Screenshot 2024-05-10 at 11 56 34 AM" src="https://github.com/unity-sds/unity-sps/assets/109703335/b80cf9ff-0d92-41bc-aeab-10704c35e7bd">
<img width="929" alt="Screenshot 2024-05-10 at 11 57 47 AM" src="https://github.com/unity-sds/unity-sps/assets/109703335/768f824d-b225-49fd-83ec-8f3029aa4ae8">

