### PR TITLE
Improving the CWL DAG

### DIFF
--- a/airflow/dags/cwl_dag_new.py
+++ b/airflow/dags/cwl_dag_new.py
@@ -1,0 +1,132 @@
+"""
+DAG to execute a generic CWL workflow.
+
+The Airflow KubernetesPodOperator starts a Docker container that includes the Docker engine and the CWL libraries.
+The "cwl-runner" tool is invoked to execute the CWL workflow.
+Parameter cwl_workflow: the URL of the CWL workflow to execute.
+Parameter args_as_json: JSON string contained the specific values for the workflow specific inputs.
+"""
+
+import json
+import logging
+import os
+import shutil
+from datetime import datetime
+
+from airflow.models.baseoperator import chain
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator, get_current_context
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
+from airflow.utils.trigger_rule import TriggerRule
+from kubernetes.client import models as k8s
+
+from airflow import DAG
+
+# The Kubernetes namespace within which the Pod is run (it must already exist)
+POD_NAMESPACE = "airflow"
+
+# The path of the working directory where the CWL workflow is executed
+# (aka the starting directory for cwl-runner).
+# This is fixed to the EFS /scratch directory in this DAG.
+WORKING_DIR = "/scratch"
+
+# default parameters
+DEFAULT_CWL_WORKFLOW = (
+    "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/echo_message.cwl"
+)
+DEFAULT_CWL_ARGUMENTS = {"message": "Hello Unity"}
+
+# Default DAG configuration
+dag_default_args = {
+    "owner": "unity-sps",
+    "depends_on_past": False,
+    "start_date": datetime.utcfromtimestamp(0),
+}
+
+# common parameters
+INPUT_PROCESSING_LABELS = ["label1", "label2"]
+
+dag = DAG(
+    dag_id="cwl_dag_new",
+    description="CWL DAG",
+    tags=["CWL"],
+    is_paused_upon_creation=False,
+    catchup=False,
+    schedule=None,
+    max_active_runs=10,
+    max_active_tasks=30,
+    default_args=dag_default_args,
+    params={
+        "cwl_workflow": Param(
+            DEFAULT_CWL_WORKFLOW, type="string", title="CWL workflow", description="The CWL workflow URL"
+        ),
+        "cwl_args": Param(
+            json.dumps(DEFAULT_CWL_ARGUMENTS),
+            type="string",
+            title="CWL workflow parameters",
+            description="The job parameters encoded as a JSON string, or the URL of a JSON or YAML file",
+        ),
+    },
+)
+
+
+def setup(ti=None, **context):
+    """
+    Task that creates the working directory on the shared volume.
+    """
+    context = get_current_context()
+    dag_run_id = context["dag_run"].run_id
+    local_dir = f"/shared-task-data/{dag_run_id}"
+    logging.info(f"Creating directory: {local_dir}")
+    os.makedirs(local_dir, exist_ok=True)
+    logging.info(f"Created directory: {local_dir}")
+
+
+setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
+
+cwl_task = KubernetesPodOperator(
+    retries=0,
+    task_id="cwl_task",
+    namespace=POD_NAMESPACE,
+    name="cwl-task-pod",
+    image="ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.0.0",
+    service_account_name="airflow-worker",
+    in_cluster=True,
+    get_logs=True,
+    startup_timeout_seconds=1200,
+    arguments=["{{ params.cwl_workflow }}", "{{ params.cwl_args }}"],
+    container_security_context={"privileged": True},
+    # container_resources=CONTAINER_RESOURCES,
+    container_logs=True,
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
+        )
+    ],
+    dag=dag,
+)
+
+
+def cleanup(**context):
+    """
+    Tasks that deletes all data shared between Tasks
+    from the Kubernetes PersistentVolume
+    """
+    dag_run_id = context["dag_run"].run_id
+    local_dir = f"/shared-task-data/{dag_run_id}"
+    if os.path.exists(local_dir):
+        shutil.rmtree(local_dir)
+        logging.info(f"Deleted directory: {local_dir}")
+    else:
+        logging.info(f"Directory does not exist, no need to delete: {local_dir}")
+
+
+cleanup_task = PythonOperator(
+    task_id="Cleanup", python_callable=cleanup, dag=dag, trigger_rule=TriggerRule.ALL_DONE
+)
+
+chain(setup_task, cwl_task, cleanup_task)

--- a/airflow/dags/cwl_dag_new.py
+++ b/airflow/dags/cwl_dag_new.py
@@ -129,8 +129,7 @@ cwl_task = KubernetesPodOperator(
     annotations={"karpenter.sh/do-not-disrupt": "true"},
     affinity=get_affinity(
         capacity_type=["spot"],
-        instance_family=["c6i", "c5"],
-        instance_cpu=["2", "4"],
+        instance_type=["r7i.xlarge"],
         anti_affinity_label=POD_LABEL,
     ),
 )

--- a/airflow/dags/cwl_dag_new.py
+++ b/airflow/dags/cwl_dag_new.py
@@ -38,6 +38,20 @@ DEFAULT_CWL_WORKFLOW = (
 )
 DEFAULT_CWL_ARGUMENTS = {"message": "Hello Unity"}
 
+# Alternative arguments to execute SBG Pre-Process
+# DEFAULT_CWL_WORKFLOW = https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl
+# DEFAULT_CWL_ARGUMENTS = https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.dev.yml
+# or:
+# DEFAULT_CWL_ARGUMENTS = {
+#     "input_processing_labels": ["label1", "label2"],
+#     "input_cmr_stac": "https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z",
+#     "input_unity_dapa_client": "40c2s0ulbhp9i0fmaph3su9jch",
+#     "input_unity_dapa_api": "https://d3vc8w9zcq658.cloudfront.net",
+#     "input_crid": "001",
+#     "output_collection_id": "urn:nasa:unity:unity:dev:SBG-L1B_PRE___1",
+#     "output_data_bucket": "sps-dev-ds-storage",
+# }
+
 # Default DAG configuration
 dag_default_args = {
     "owner": "unity-sps",

--- a/airflow/dags/cwl_dag_new.py
+++ b/airflow/dags/cwl_dag_new.py
@@ -36,21 +36,16 @@ WORKING_DIR = "/scratch"
 DEFAULT_CWL_WORKFLOW = (
     "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/main/demos/echo_message.cwl"
 )
-DEFAULT_CWL_ARGUMENTS = {"message": "Hello Unity"}
+DEFAULT_CWL_ARGUMENTS = json.dumps({"message": "Hello Unity"})
 
 # Alternative arguments to execute SBG Pre-Process
-# DEFAULT_CWL_WORKFLOW = https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl
-# DEFAULT_CWL_ARGUMENTS = https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.dev.yml
-# or:
-# DEFAULT_CWL_ARGUMENTS = {
-#     "input_processing_labels": ["label1", "label2"],
-#     "input_cmr_stac": "https://cmr.earthdata.nasa.gov/search/granules.stac?collection_concept_id=C2408009906-LPCLOUD&temporal[]=2023-08-10T03:41:03.000Z,2023-08-10T03:41:03.000Z",
-#     "input_unity_dapa_client": "40c2s0ulbhp9i0fmaph3su9jch",
-#     "input_unity_dapa_api": "https://d3vc8w9zcq658.cloudfront.net",
-#     "input_crid": "001",
-#     "output_collection_id": "urn:nasa:unity:unity:dev:SBG-L1B_PRE___1",
-#     "output_data_bucket": "sps-dev-ds-storage",
-# }
+# DEFAULT_CWL_WORKFLOW = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl"
+# DEFAULT_CWL_ARGUMENTS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.dev.yml"
+
+# Alternative arguments to execute SBG end-to-end
+# DEFAULT_CWL_WORKFLOW = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/L1-to-L2-e2e.cwl"
+# DEFAULT_CWL_ARGUMENTS = "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/L1-to-L2-e2e.dev.yml"
+
 
 # Default DAG configuration
 dag_default_args = {
@@ -77,7 +72,7 @@ dag = DAG(
             DEFAULT_CWL_WORKFLOW, type="string", title="CWL workflow", description="The CWL workflow URL"
         ),
         "cwl_args": Param(
-            json.dumps(DEFAULT_CWL_ARGUMENTS),
+            DEFAULT_CWL_ARGUMENTS,
             type="string",
             title="CWL workflow parameters",
             description="The job parameters encoded as a JSON string, or the URL of a JSON or YAML file",

--- a/airflow/dags/karpenter_test.py
+++ b/airflow/dags/karpenter_test.py
@@ -45,8 +45,7 @@ compute_task = KubernetesPodOperator(
     annotations={"karpenter.sh/do-not-disrupt": "true"},
     affinity=get_affinity(
         capacity_type=["spot"],
-        instance_family=["c6i", "c5"],
-        instance_cpu=["2", "4"],
+        instance_type=["c6i.xlarge", "c5.xlarge"],
         anti_affinity_label=POD_LABEL,
     ),
 )
@@ -69,8 +68,7 @@ memory_task = KubernetesPodOperator(
     annotations={"karpenter.sh/do-not-disrupt": "true"},
     affinity=get_affinity(
         capacity_type=["spot"],
-        instance_family=["r6i", "r5"],
-        instance_cpu=["2", "4"],
+        instance_type=["r6i.xlarge", "r5.xlarge"],
         anti_affinity_label=POD_LABEL,
     ),
 )
@@ -94,8 +92,7 @@ general_task = KubernetesPodOperator(
     annotations={"karpenter.sh/do-not-disrupt": "true"},
     affinity=get_affinity(
         capacity_type=["spot"],
-        instance_family=["m6i", "m5"],
-        instance_cpu=["2", "4"],
+        instance_type=["m6i.xlarge", "m5.xlarge"],
         anti_affinity_label=POD_LABEL,
     ),
 )

--- a/airflow/plugins/unity_sps_utils.py
+++ b/airflow/plugins/unity_sps_utils.py
@@ -3,9 +3,7 @@ Module containing common utilities for the Unity Science Processing System.
 """
 
 
-def get_affinity(
-    capacity_type: list[str], instance_family: list[str], instance_cpu: list[str], anti_affinity_label: str
-):
+def get_affinity(capacity_type: list[str], instance_type: list[str], anti_affinity_label: str):
 
     affinity = {
         "nodeAffinity": {
@@ -28,15 +26,10 @@ def get_affinity(
                     {
                         "matchExpressions": [
                             {
-                                "key": "karpenter.k8s.aws/instance-family",
+                                "key": "node.kubernetes.io/instance-type",
                                 "operator": "In",
-                                "values": instance_family,
-                            },
-                            {
-                                "key": "karpenter.k8s.aws/instance-cpu",
-                                "operator": "In",
-                                "values": instance_cpu,
-                            },
+                                "values": instance_type,
+                            }
                         ]
                     }
                 ]

--- a/utils/airflow_kpo_pv_access.yaml
+++ b/utils/airflow_kpo_pv_access.yaml
@@ -1,0 +1,46 @@
+# Pod that mounts the Kubernetes Persistent Volume "airflow-kpo"
+# where the DAGs write shared data so that the location can be inspected
+#
+# To use:
+# kubectl create -f airflow_kpo_pv_access.yaml -n airflow
+# kubectl get pods -n airflow --> identify the pod id
+# kubectl exec -it <airflow-kpo-pv-access-67f65c99b7-9nhgb>  -n airflow sh
+# ls -l /scratch
+#
+# To delete the pod:
+# kubectl delete deployment airflow-kpo-pv-access -n airflow
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-kpo-pv-access
+  namespace: airflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybx
+        image: busybox
+        command: ["sleep"]
+        args: ["infinity"]
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 150Mi
+        volumeMounts:
+        - name: efs
+          mountPath: "/scratch"
+      volumes:
+      - name: efs
+        persistentVolumeClaim:
+          claimName: airflow-kpo

--- a/utils/trigger_dag.py
+++ b/utils/trigger_dag.py
@@ -1,0 +1,53 @@
+"""
+Script to trigger a DAG
+Syntax: python trigger_dag.py -d <dag_id> -n <num_times>
+
+Example:
+export AIRFLOW_HOST=http://k8s-airflow-airflowi-004fdefd11-514392646.us-west-2.elb.amazonaws.com:5000
+export AIRFLOW_USERNAME=....
+export AIRFLOW_PASSWORD=...
+source .venv/bin/activate
+python utils/trigger_dag.py -d busybox -n 1
+"""
+
+import argparse
+import os
+import time
+from datetime import datetime, timezone
+from pprint import pprint
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--dag", help="ID of DAG to run", type=str)
+    parser.add_argument("-n", "--num", help="Number of DAG runs", type=int, default=1)
+    args = parser.parse_args()
+    dag = args.dag
+    num = args.num
+
+    # get airflow host,user,pwd from ENV variables
+    airflow_host = os.getenv("AIRFLOW_HOST")
+    airflow_username = os.getenv("AIRFLOW_USERNAME")
+    airflow_password = os.getenv("AIRFLOW_PASSWORD")
+
+    url = f"{airflow_host}/api/v1/dags/{dag}/dagRuns"
+    headers = {"Content-type": "application/json", "Accept": "text/json"}
+
+    for i in range(num):
+        dt_now = datetime.now(timezone.utc)
+        logical_date = dt_now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        data = {"logical_date": logical_date}
+        result = requests.post(
+            url, json=data, headers=headers, auth=HTTPBasicAuth(airflow_username, airflow_password)
+        )
+        result_json = result.json()
+        pprint(result_json)
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

- This PR adds an improved version of the CWL DAG which a) does not use the Pod template (which would need to be copied to the DAGS folder separately) and b) uses the Karpenter node pool
- Also added a few additional utilities: a Kubernetes deployment that can be used to mount the shared volume where the tasks write data, and a script to submit N DAGs

## Proposed Changes

- [ADD] New "cwl_dag_new" DAG that can execute a generic DAG on Karpenter node pools
- [ADD] Utilities to monitor the shared volume and to submit N DAGs programmatically

## Issues

- https://github.com/unity-sds/unity-sps/issues/64

## Testing

- The CWL DAG was able to execute 10 concurrent DAGs of the "CWL echo" workflow.
- Also able to execute the CWL DAG for the SBG PreProcess step
