### PR TITLE
Add some utilities scripts

### DIFF
--- a/utils/post_deployment.sh
+++ b/utils/post_deployment.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#set -ex
+
+# Script to execute post-deployment operations
+# Pre-Requisites:
+# - SPS has been deployed successfully
+# - AWS credentials are renewed and set in the environment
+# Syntax:
+# ./post_deployment.sh <WPST_API>
+# Example:
+# ./post_deployment.sh http://k8s-airflow-ogcproce-944e409e1d-687289935.us-west-2.elb.amazonaws.com:5001
+
+# script argument: the $WPST_API
+export WPST_API=$1
+
+# list of processes to be registered
+declare -a procs=("cwl_dag" "karpenter_test" "sbg_L1_to_L2_e2e_cwl_step_by_step_dag")
+
+for proc in "${procs[@]}"
+do
+   echo " "
+   # register process
+   echo "Registering process: $proc"
+   curl -X POST -H "Content-Type: application/json; charset=utf-8" --data '{"id":"'${proc}'", "version": "1.0.0"}'  "${WPST_API}/processes"
+   # unregister process
+   # echo "Unregistering process: $proc"
+   # curl -X DELETE -H "Content-Type: application/json; charset=utf-8" "${WPST_API}/processes/${proc}"
+   echo " "
+done

--- a/utils/unity_sps_deploy_or_destroy_sps.sh
+++ b/utils/unity_sps_deploy_or_destroy_sps.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -ex
+# Script to deploy or destroy the Unity EKS, Karpenter of Airflow
+#
+# Syntax: ./unity_sps_deploy_or_destroy_sps.sh deploy|destroy eks|karpenter|airflow
+#
+# Pre-requisites:
+# o Customize all parameters in the header section to target your desired deployment
+# o Renew the proper AWS credentials
+#
+# Note:
+# Components must be deployed in this order:
+# deploy eks > karpenter > airflow
+# Components must be destroyed in the revers order:
+# destroy airflow > karpenter > eks
+
+# Note:
+# Must make sure we don't check in a new version of this script with a real AWS account number
+
+# =============== START HEADER: customize this section =================
+
+# set venue dependent AWS profile
+export AWS_PROFILE=XXXXXXXXXXXX_mcp-tenantOperator
+export AWS_REGION=us-west-2
+
+# set cluster parameters
+export PROJECT=unity
+export SERVICE_AREA=sps
+export VENUE=dev
+export DEPLOYMENT=luca
+export COUNTER=7
+export BUCKET=unity-unity-dev-bucket
+
+# the root directory of the "unity-sps" installation
+export UNITY_SPS_DIR=/Users/cinquini/PycharmProjects/unity-sps
+
+# ============= END HEADER: do not change what follows ====================
+
+# "deploy" or "destroy"
+ACTION=$1
+
+# "eks" or "karpenter" or "airflow"
+COMPONENT=$2
+
+export CLUSTER_NAME=unity-${VENUE}-sps-eks-${DEPLOYMENT}-${COUNTER}
+export KUBECONFIG=${UNITY_SPS_DIR}/terraform-unity/modules/terraform-unity-sps-eks/$CLUSTER_NAME.cfg
+
+if [ "$COMPONENT" = "eks" ]; then
+   tf_dir=${UNITY_SPS_DIR}/terraform-unity/modules/terraform-unity-sps-eks
+elif [ "$COMPONENT" = "karpenter" ]; then
+   tf_dir=${UNITY_SPS_DIR}/terraform-unity/modules/terraform-unity-sps-karpenter
+elif [ "$COMPONENT" = "airflow" ]; then
+   tf_dir=${UNITY_SPS_DIR}/terraform-unity
+fi
+export TFVARS_FILENAME=unity-${VENUE}-sps-${COMPONENT}-${DEPLOYMENT}-${COUNTER}.tfvars
+
+# initialize Terraform
+cd $tf_dir
+tfswitch 1.8.2
+export KEY=sps/tfstates/${PROJECT}-${VENUE}-${SERVICE_AREA}-${COMPONENT}-${DEPLOYMENT}-${COUNTER}.tfstate
+terraform init -reconfigure -backend-config="bucket=$BUCKET" -backend-config="key=$KEY"
+terraform get -update
+
+# if new cluster --> create new tfvars file
+mkdir -p tfvars
+if ! [ -f tfvars/${TFVARS_FILENAME} ]; then
+  terraform-docs tfvars hcl . --output-file "tfvars/${TFVARS_FILENAME}"
+fi
+
+# switch between DEPLOYMENTs
+if [ "$COMPONENT" = "eks" ]; then
+    if [ "$ACTION" = "deploy" ]; then
+       echo "Deploying $COMPONENT"
+       terraform apply --auto-approve --var-file=tfvars/$TFVARS_FILENAME
+       aws eks update-kubeconfig --region us-west-2 --name $CLUSTER_NAME --kubeconfig ${KUBECONFIG}
+       kubectl get all -A
+    elif [ "$ACTION" = "destroy" ]; then
+       echo "Destroying $COMPONENT"
+       terraform destroy --auto-approve --var-file=tfvars/$TFVARS_FILENAME
+    fi
+elif [ "$COMPONENT" = "airflow" ]; then
+    if [ "$ACTION" = "deploy" ]; then
+       echo "Deploying $COMPONENT"
+       terraform apply --auto-approve --var-file=tfvars/$TFVARS_FILENAME
+       kubectl get all -n airflow
+    elif [ "$ACTION" = "destroy" ]; then
+       echo "Destroying $COMPONENT"
+       terraform destroy --auto-approve --var-file=tfvars/$TFVARS_FILENAME
+    fi
+elif [ "$COMPONENT" = "karpenter" ]; then
+    if [ "$ACTION" = "deploy" ]; then
+       echo "Deploying $COMPONENT"
+       terraform apply --auto-approve --var-file=tfvars/$TFVARS_FILENAME
+       kubectl get all -A
+    elif [ "$ACTION" = "destroy" ]; then
+       echo "Destroying $COMPONENT"
+       terraform destroy --auto-approve --var-file=tfvars/$TFVARS_FILENAME
+    fi
+fi


### PR DESCRIPTION
## Purpose

- Add some utilities script to the code repository

## Proposed Changes

- [ADD] Script unity_sps_deploy_or_destroy_sps.sh is used to deploy/undeploy eks, karpenter, airflow
- [ADD] Script post_deployment.sh is used to register OGC processes after an SPS instance has been deployed

## Issues

- [Store S3 State on S3](https://github.com/unity-sds/unity-sps/issues/132)

## Testing

- The deployment/undeplyment script has been tested multiple times successfully
- Also the OGC registration script has been tested successfully after the Dev Nightly venue was deployed
