### PR TITLE
Parametrize the integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,15 +29,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[test]"
 
-#    - name: MCP Venue Test - Integration tests
-#      id: mcp_venue_test_integration_tests
-#      continue-on-error: true
-#      env:
-#        AIRFLOW_WEBSERVER_PASSWORD: ${{ secrets.MCP_VENUE_TEST_AIRFLOW_WEBSERVER_PASSWORD }}
-#      run: |
-#        pytest -vv --gherkin-terminal-reporter \
-#        unity-test/system/integration \
-#        --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_AIRFLOW_ENDPOINT || vars.MCP_VENUE_TEST_AIRFLOW_ENDPOINT }}
 
     - name: MCP Venue Dev - Integration tests
       id: mcp_venue_dev_integration_tests
@@ -50,21 +41,32 @@ jobs:
         --venue="dev" \
         --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_DEV_AIRFLOW_ENDPOINT || vars.MCP_VENUE_DEV_AIRFLOW_ENDPOINT }}
 
+    - name: MCP Venue Test - Integration tests
+      id: mcp_venue_test_integration_tests
+      continue-on-error: true
+      env:
+        AIRFLOW_WEBSERVER_PASSWORD: ${{ secrets.MCP_VENUE_TEST_AIRFLOW_WEBSERVER_PASSWORD }}
+      run: |
+        pytest -vv --gherkin-terminal-reporter \
+        unity-test/system/integration \
+        --venue="test" \
+        --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_AIRFLOW_ENDPOINT || vars.MCP_VENUE_TEST_AIRFLOW_ENDPOINT }}
+
     - name: Check Integration Tests Results
       if: always()
       run: |
         dev_status=${{ steps.mcp_venue_dev_integration_tests.outcome }}
-        # test_status=${{ steps.mcp_venue_test_integration_tests.outcome }}
+        test_status=${{ steps.mcp_venue_test_integration_tests.outcome }}
         echo "Dev Venue Integration Tests status: $dev_status"
-        # echo "Test Venue Integration Tests status: $test_status"
+        echo "Test Venue Integration Tests status: $test_status"
 
         if [ "$dev_status" != "success" ]; then
           echo "MCP Venue Dev Integration Tests failed."
           exit 1
         fi
 
-#        # Uncomment this block when MCP Venue Test Integration tests are re-enabled
-#        if [ "$test_status" != "success" ]; then
-#          echo "MCP Venue Test Integration Tests failed."
-#          exit 1
-#        fi
+        # Uncomment this block when MCP Venue Test Integration tests are re-enabled
+        if [ "$test_status" != "success" ]; then
+          echo "MCP Venue Test Integration Tests failed."
+          exit 1
+        fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,9 +10,9 @@ on:
       MCP_VENUE_DEV_AIRFLOW_ENDPOINT:
         description: "Base URL for the Airflow endpoint in MCP Venue Dev (i.e. http://abc.def.ghi:port-number)"
         type: string
-      # MCP_VENUE_TEST_AIRFLOW_ENDPOINT:
-      #   description: "Base URL for the Airflow endpoint in MCP Venue Test (i.e. http://abc.def.ghi:port-number)"
-      #   type: string
+      MCP_VENUE_TEST_AIRFLOW_ENDPOINT:
+         description: "Base URL for the Airflow endpoint in MCP Venue Test (i.e. http://abc.def.ghi:port-number)"
+         type: string
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -32,6 +32,8 @@ jobs:
     - name: MCP Venue Test - Integration tests
       id: mcp_venue_test_integration_tests
       continue-on-error: true
+      env:
+        AIRFLOW_WEBSERVER_PASSWORD: ${{ secrets.MCP_VENUE_TEST_AIRFLOW_WEBSERVER_PASSWORD }}
       run: |
         pytest -vv --gherkin-terminal-reporter \
         unity-test/system/integration \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,15 +29,15 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[test]"
 
-    - name: MCP Venue Test - Integration tests
-      id: mcp_venue_test_integration_tests
-      continue-on-error: true
-      env:
-        AIRFLOW_WEBSERVER_PASSWORD: ${{ secrets.MCP_VENUE_TEST_AIRFLOW_WEBSERVER_PASSWORD }}
-      run: |
-        pytest -vv --gherkin-terminal-reporter \
-        unity-test/system/integration \
-        --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_AIRFLOW_ENDPOINT || vars.MCP_VENUE_TEST_AIRFLOW_ENDPOINT }}
+#    - name: MCP Venue Test - Integration tests
+#      id: mcp_venue_test_integration_tests
+#      continue-on-error: true
+#      env:
+#        AIRFLOW_WEBSERVER_PASSWORD: ${{ secrets.MCP_VENUE_TEST_AIRFLOW_WEBSERVER_PASSWORD }}
+#      run: |
+#        pytest -vv --gherkin-terminal-reporter \
+#        unity-test/system/integration \
+#        --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_AIRFLOW_ENDPOINT || vars.MCP_VENUE_TEST_AIRFLOW_ENDPOINT }}
 
     - name: MCP Venue Dev - Integration tests
       id: mcp_venue_dev_integration_tests
@@ -53,17 +53,17 @@ jobs:
       if: always()
       run: |
         dev_status=${{ steps.mcp_venue_dev_integration_tests.outcome }}
-        test_status=${{ steps.mcp_venue_test_integration_tests.outcome }}
+        # test_status=${{ steps.mcp_venue_test_integration_tests.outcome }}
         echo "Dev Venue Integration Tests status: $dev_status"
-        echo "Test Venue Integration Tests status: $test_status"
+        # echo "Test Venue Integration Tests status: $test_status"
 
         if [ "$dev_status" != "success" ]; then
           echo "MCP Venue Dev Integration Tests failed."
           exit 1
         fi
 
-        # Uncomment this block when MCP Venue Test Integration tests are re-enabled
-        if [ "$test_status" != "success" ]; then
-          echo "MCP Venue Test Integration Tests failed."
-          exit 1
-        fi
+#        # Uncomment this block when MCP Venue Test Integration tests are re-enabled
+#        if [ "$test_status" != "success" ]; then
+#          echo "MCP Venue Test Integration Tests failed."
+#          exit 1
+#        fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -29,6 +29,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[test]"
 
+    - name: MCP Venue Test - Integration tests
+      id: mcp_venue_test_integration_tests
+      continue-on-error: true
+      run: |
+        pytest -vv --gherkin-terminal-reporter \
+        unity-test/system/integration \
+        --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_AIRFLOW_ENDPOINT || vars.MCP_VENUE_TEST_AIRFLOW_ENDPOINT }}
+
     - name: MCP Venue Dev - Integration tests
       id: mcp_venue_dev_integration_tests
       continue-on-error: true
@@ -39,21 +47,13 @@ jobs:
         unity-test/system/integration \
         --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_DEV_AIRFLOW_ENDPOINT || vars.MCP_VENUE_DEV_AIRFLOW_ENDPOINT }}
 
-    # - name: MCP Venue Test - Integration tests
-    #   id: mcp_venue_test_integration_tests
-    #   continue-on-error: true
-    #   run: |
-    #     pytest -vv --gherkin-terminal-reporter \
-    #     unity-test/system/integration \
-    #     --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_AIRFLOW_ENDPOINT || vars.MCP_VENUE_TEST_AIRFLOW_ENDPOINT }}
-
     - name: Check Integration Tests Results
       if: always()
       run: |
         dev_status=${{ steps.mcp_venue_dev_integration_tests.outcome }}
-        # test_status=${{ steps.mcp_venue_test_integration_tests.outcome }}
-        echo "Dev Integration Tests: $dev_status"
-        # echo "Test Integration Tests: $test_status"
+        test_status=${{ steps.mcp_venue_test_integration_tests.outcome }}
+        echo "Dev Venue Integration Tests status: $dev_status"
+        echo "Test Venue Integration Tests status: $test_status"
 
         if [ "$dev_status" != "success" ]; then
           echo "MCP Venue Dev Integration Tests failed."
@@ -61,7 +61,7 @@ jobs:
         fi
 
         # Uncomment this block when MCP Venue Test Integration tests are re-enabled
-        # if [ "$test_status" != "success" ]; then
-        #   echo "MCP Venue Test Integration Tests failed."
-        #   exit 1
-        # fi
+        if [ "$test_status" != "success" ]; then
+          echo "MCP Venue Test Integration Tests failed."
+          exit 1
+        fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         pytest -vv --gherkin-terminal-reporter \
         unity-test/system/integration \
+        --venue="dev" \
         --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_DEV_AIRFLOW_ENDPOINT || vars.MCP_VENUE_DEV_AIRFLOW_ENDPOINT }}
 
     - name: Check Integration Tests Results

--- a/unity-test/conftest.py
+++ b/unity-test/conftest.py
@@ -26,8 +26,8 @@ def pytest_addoption(parser):
         "--venue",
         action="store",
         default=None,
-        choices=("dev", "int", "ops"),
-        help="The venue in which the cluster will be deployed (dev, int, ops).",
+        choices=("dev", "test", "ops"),
+        help="The venue in which the cluster will be deployed (dev, test, ops).",
     )
     parser.addoption(
         "--developer",
@@ -77,6 +77,12 @@ def airflow_api_url(request):
 def ogc_processes_api_url(request):
     url = request.config.getoption("--ogc-processes-endpoint")
     return url
+
+
+@pytest.fixture(scope="session")
+def venue(request):
+    venue = request.config.getoption("--venue")
+    return venue
 
 
 @pytest.fixture(scope="session")

--- a/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
+++ b/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
@@ -26,7 +26,7 @@ def trigger_dag(airflow_api_url, airflow_api_auth):
     response = requests.post(
         f"{airflow_api_url}/api/v1/dags/sbg_preprocess_cwl_dag/dagRuns",
         auth=airflow_api_auth,
-        json={"note": "Triggered by unity-test suite"},
+        json={"conf": {"cwl_args": "abc123"}},
     )
     return response
 

--- a/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
+++ b/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
@@ -8,6 +8,9 @@ FILE_PATH = Path(__file__)
 FEATURES_DIR = FILE_PATH.parent.parent / "features"
 FEATURE_FILE: Path = FEATURES_DIR / "sbg_preprocess_workflow.feature"
 
+# DAG parameters are venue specific
+DAG_ID = "sbg_preprocess_cwl_dag"
+
 
 @scenario(FEATURE_FILE, "Check SBG Preprocess Workflow")
 def test_check_sbg_preprocess_workflow():
@@ -20,13 +23,16 @@ def api_up_and_running():
 
 
 @when("I trigger a dag run for the SBG Preprocess dag", target_fixture="response")
-def trigger_dag(airflow_api_url, airflow_api_auth):
+def trigger_dag(airflow_api_url, airflow_api_auth, venue):
     # leaving out dag_run_id to avoid conflicts with previous runs- we can always fetch it from the response
     # unsure about contents of the conf argument, though
+    cwl_workflow = "abc"
+    cwl_args = "123"
+    print(f"VENUE={venue}")
     response = requests.post(
-        f"{airflow_api_url}/api/v1/dags/sbg_preprocess_cwl_dag/dagRuns",
+        f"{airflow_api_url}/api/v1/dags/{DAG_ID}/dagRuns",
         auth=airflow_api_auth,
-        json={"conf": {"cwl_args": "abc123"}},
+        json={"conf": {"cwl_workflow": f"{cwl_workflow}", "cwl_args": f"{cwl_args}"}},
     )
     return response
 

--- a/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
+++ b/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
@@ -2,6 +2,8 @@
 # The workflow parameters are contained in a YAML file which is venue-dependent.
 # The SBG Preprocess DAG must already be deployed in Airflow,
 # and it is invoked via the Airflow API.
+# The CWL task is executed via a KubernetesPodOperator on a worker node
+# that is dynamically provisioned by Karpenter.
 from pathlib import Path
 
 import backoff
@@ -15,8 +17,14 @@ FEATURE_FILE: Path = FEATURES_DIR / "sbg_preprocess_workflow.feature"
 # DAG parameters are venue specific
 DAG_ID = "sbg_preprocess_cwl_dag"
 SBG_PREPROCESS_PARAMETERS = {
-    "dev": {"cwl_workflow": "abc", "cwl_args": "123"},
-    "test": {"cwl_workflow": "cde", "cwl_args": "456"},
+    "dev": {
+        "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl",
+        "cwl_args": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.dev.yml",
+    },
+    "test": {
+        "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl",
+        "cwl_args": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.test.yml",
+    },
 }
 
 

--- a/utils/post_deployment.sh
+++ b/utils/post_deployment.sh
@@ -14,7 +14,7 @@
 export WPST_API=$1
 
 # list of processes to be registered
-declare -a procs=("cwl_dag" "karpenter_test" "sbg_L1_to_L2_e2e_cwl_step_by_step_dag")
+declare -a procs=("cwl_dag" "karpenter_test" "sbg_preprocess_cwl_dag")
 
 for proc in "${procs[@]}"
 do

--- a/utils/trigger_dag.py
+++ b/utils/trigger_dag.py
@@ -41,6 +41,10 @@ def main():
         dt_now = datetime.now(timezone.utc)
         logical_date = dt_now.strftime("%Y-%m-%dT%H:%M:%SZ")
         data = {"logical_date": logical_date}
+        # Example on how to pass DAG specific parameters
+        # data = {"logical_date": logical_date,
+        #        "conf": {"cwl_args": "abc123"}
+        #       }
         result = requests.post(
             url, json=data, headers=headers, auth=HTTPBasicAuth(airflow_username, airflow_password)
         )

--- a/utils/unity_sps_deploy_or_destroy_sps.sh
+++ b/utils/unity_sps_deploy_or_destroy_sps.sh
@@ -14,6 +14,11 @@ set -ex
 # Components must be destroyed in the revers order:
 # destroy airflow > karpenter > eks
 
+# Note: the first time you run "deploy" on eks/karpenter/airflow, you don't already have the $TFVARS_FILENAME
+# in the proper directory, the script will stop because it cannot parse the file that was automatically generated.
+# Edit that file: remove the first and last line, and add the specific values for your deployment.
+# Then run the script again.
+
 # Note:
 # Must make sure we don't check in a new version of this script with a real AWS account number
 


### PR DESCRIPTION
## Purpose

- This PR enables the SPS Integration Tests, which currently execute the SBG Preprocess workflow, to execute on the "dev" and "test" venue by passing the proper YAML file.

## Proposed Changes

- [ADD] Support for parametrizing the Integration Tests so they can use different values on different values

## Issues

- https://github.com/unity-sds/unity-sps/issues/155

## Testing

- Integration tests using this branch succeed on DEV and TEST venue, in both cases running the full SBG Preprocess workflow
