### PR TITLE
Upgrading to MCP AMI 1.29

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-eks/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-eks/README.md
@@ -20,7 +20,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module | unity-sps-2.0.1 |
+| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module | unity-sps-2.1.0 |
 
 ## Resources
 

--- a/terraform-unity/modules/terraform-unity-sps-eks/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-eks/main.tf
@@ -15,7 +15,8 @@ resource "random_id" "counter" {
 }
 
 module "unity-eks" {
-  source          = "git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.0.1"
+
+  source          = "git@github.com:unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.1.0"
   deployment_name = local.cluster_name
   nodegroups      = var.nodegroups
   aws_auth_roles = [{
@@ -28,7 +29,7 @@ module "unity-eks" {
     Component = "eks"
     Stack     = "eks"
   })
-  cluster_version = "1.27"
+  cluster_version = "1.29"
 }
 
 # add extra policies as inline policy


### PR DESCRIPTION
## Purpose

- This PR upgrades the SPS cluster to use version 1.29 of the MCP golden AMIs

## Proposed Changes

- [CHANGE] Cluster version to be "1.29", based on new unity-cs-infra tag "unity-sps-2.1.0"

## Issues

- https://github.com/unity-sds/unity-sps/issues/159

## Testing

- Redeployed SPS infrastructure to unity-venue-test using the upgraded branch, deployed was successful and so were the tests
