### PR TITLE
Define 3 new SSM parameters to store health check endpoints

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -808,6 +808,22 @@ resource "aws_ssm_parameter" "airflow_ui_url" {
   })
 }
 
+resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "airflow-ui"])))
+  description = "The URL of the Airflow UI."
+  type        = "String"
+  value       = jsonencode({
+    "componentName": "Airflow UI"
+    "healthCheckUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/health"
+    "landingPageUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000"
+  })
+  tags = merge(local.common_tags, {
+    Name      = format(local.resource_name_prefix, "health-check-endpoints-airflow_ui")
+    Component = "SSM"
+    Stack     = "SSM"
+  })
+}
+
 resource "aws_ssm_parameter" "airflow_api_url" {
   name        = format("/%s", join("/", compact(["", var.project, var.venue, var.service_area, var.deployment_name, local.counter, "processing", "airflow", "api_url"])))
   description = "The URL of the Airflow REST API."
@@ -815,6 +831,22 @@ resource "aws_ssm_parameter" "airflow_api_url" {
   value       = "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1"
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "endpoints-airflow_api")
+    Component = "SSM"
+    Stack     = "SSM"
+  })
+}
+
+resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "airflow-api"])))
+  description = "The URL of the Airflow REST API."
+  type        = "String"
+  value       = jsonencode({
+    "componentName": "Airflow API"
+    "healthCheckUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1/health"
+    "landingPageUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1"
+  })
+  tags = merge(local.common_tags, {
+    Name      = format(local.resource_name_prefix, "health-check-endpoints-airflow_api")
     Component = "SSM"
     Stack     = "SSM"
   })
@@ -851,6 +883,22 @@ resource "aws_ssm_parameter" "ogc_processes_api_url" {
   value       = "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001"
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "endpoints-ogc_processes_api")
+    Component = "SSM"
+    Stack     = "SSM"
+  })
+}
+
+resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "ogc-api"])))
+  description = "The URL of the OGC Processes REST API."
+  type        = "String"
+  value       = jsonencode({
+    "componentName": "OGC API"
+    "healthCheckUrl": "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001/health"
+    "landingPageUrl": "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001"
+  })
+  tags = merge(local.common_tags, {
+    Name      = format(local.resource_name_prefix, "health-check-endpoints-ogc_processes_api")
     Component = "SSM"
     Stack     = "SSM"
   })

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -812,10 +812,10 @@ resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
   name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "airflow-ui"])))
   description = "The URL of the Airflow UI."
   type        = "String"
-  value       = jsonencode({
-    "componentName": "Airflow UI"
-    "healthCheckUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/health"
-    "landingPageUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000"
+  value = jsonencode({
+    "componentName" : "Airflow UI"
+    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/health"
+    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000"
   })
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "health-check-endpoints-airflow_ui")
@@ -840,10 +840,10 @@ resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
   name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "airflow-api"])))
   description = "The URL of the Airflow REST API."
   type        = "String"
-  value       = jsonencode({
-    "componentName": "Airflow API"
-    "healthCheckUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1/health"
-    "landingPageUrl": "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1"
+  value = jsonencode({
+    "componentName" : "Airflow API"
+    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1/health"
+    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1"
   })
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "health-check-endpoints-airflow_api")
@@ -892,10 +892,10 @@ resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
   name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "ogc-api"])))
   description = "The URL of the OGC Processes REST API."
   type        = "String"
-  value       = jsonencode({
-    "componentName": "OGC API"
-    "healthCheckUrl": "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001/health"
-    "landingPageUrl": "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001"
+  value = jsonencode({
+    "componentName" : "OGC API"
+    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001/health"
+    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001"
   })
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "health-check-endpoints-ogc_processes_api")


### PR DESCRIPTION
## Purpose

- Expose the SPS endpoints for Airflow UI, API, and OGC API.
- Endpoints must be defined as SSM parameters with a specific format.

SSM Parameter names must start with: `/unity/${project}/${venue}/component/`

SSM Parameter endpoint format

```json
{
    "componentName": "Airflow UI",
    "healthCheckUrl": "https:/....",
    "landingPageUrl": "https://..."
}
```

## Proposed Changes

- [ADD] SSM parameters: /unity/unity/dev/component/airflow-ui, /unity/unity/dev/component/airflow-api, /unity/unity/dev/component/ogc-api

## Issues

- #172 - Expose SPS health check endpoints

## Testing

Deployed to `unity-venue-dev` and reviewed SSM Parameters. The following parameters were created:

![Screenshot 2024-07-17 at 08 25 41](https://github.com/user-attachments/assets/5d2c5029-5a78-4d31-a936-b372e121e794)

Reviewed the content of each new parameter and confirmed that SSM parameter string can be loaded into correctly formatted JSON:

```bash
# Airflow UI: 
{
  "componentName": "Airflow UI",
  "healthCheckUrl": "http://k8s-airflow-airflowi-xxx.com:5000/health",
  "landingPageUrl": "http://k8s-airflow-airflowi-xxx.com:5000"
}

# Airflow API: 
{
  "componentName": "Airflow API",
  "healthCheckUrl": "http://k8s-airflow-airflowi-xxx.com:5000/api/v1/health",
  "landingPageUrl": "http://k8s-airflow-airflowi-xxx.com:5000/api/v1"
}

# OGC API: 
{
  "componentName": "OGC API",
  "healthCheckUrl": "http://k8s-airflow-ogcproce-xxx.com:5001/health",
  "landingPageUrl": "http://k8s-airflow-ogcproce-xxx.com:5001"
}
```

*Note:* URLs are shortened for readability.
