### PR TITLE
127 health check endpoints

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/README.md
@@ -65,11 +65,14 @@ No modules.
 | [aws_sns_topic_subscription.s3_isl_event_subscription](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/sns_topic_subscription) | resource |
 | [aws_sqs_queue.s3_isl_event_queue](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue_policy.s3_isl_event_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/sqs_queue_policy) | resource |
+| [aws_ssm_parameter.airflow_api_health_check_endpoint](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.airflow_api_url](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.airflow_dag_trigger_lambda_package](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.airflow_logs](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.airflow_ui_health_check_endpoint](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.airflow_ui_url](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.isl_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.ogc_processes_api_health_check_endpoint](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ogc_processes_api_url](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ogc_processes_ui_url](https://registry.terraform.io/providers/hashicorp/aws/5.47.0/docs/resources/ssm_parameter) | resource |
 | [helm_release.airflow](https://registry.terraform.io/providers/hashicorp/helm/2.13.1/docs/resources/release) | resource |

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -823,7 +823,7 @@ resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
     Stack     = "SSM"
   })
   lifecycle {
-    ignore_changes = [ value ]
+    ignore_changes = [value]
   }
 }
 
@@ -854,7 +854,7 @@ resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
     Stack     = "SSM"
   })
   lifecycle {
-    ignore_changes = [ value ]
+    ignore_changes = [value]
   }
 }
 
@@ -909,7 +909,7 @@ resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
     Stack     = "SSM"
   })
   lifecycle {
-    ignore_changes = [ value ]
+    ignore_changes = [value]
   }
 }
 

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -809,7 +809,7 @@ resource "aws_ssm_parameter" "airflow_ui_url" {
 }
 
 resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
-  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "airflow-ui"])))
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, "airflow-ui"])))
   description = "The URL of the Airflow UI."
   type        = "String"
   value = jsonencode({
@@ -822,6 +822,9 @@ resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
     Component = "SSM"
     Stack     = "SSM"
   })
+  lifecycle {
+    ignore_changes = [ all ]
+  }
 }
 
 resource "aws_ssm_parameter" "airflow_api_url" {
@@ -837,7 +840,7 @@ resource "aws_ssm_parameter" "airflow_api_url" {
 }
 
 resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
-  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "airflow-api"])))
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, "airflow-api"])))
   description = "The URL of the Airflow REST API."
   type        = "String"
   value = jsonencode({
@@ -850,6 +853,9 @@ resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
     Component = "SSM"
     Stack     = "SSM"
   })
+  lifecycle {
+    ignore_changes = [ all ]
+  }
 }
 
 resource "aws_ssm_parameter" "airflow_logs" {
@@ -889,7 +895,7 @@ resource "aws_ssm_parameter" "ogc_processes_api_url" {
 }
 
 resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
-  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", "ogc-api"])))
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, "ogc-api"])))
   description = "The URL of the OGC Processes REST API."
   type        = "String"
   value = jsonencode({
@@ -902,6 +908,9 @@ resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
     Component = "SSM"
     Stack     = "SSM"
   })
+  lifecycle {
+    ignore_changes = [ all ]
+  }
 }
 
 resource "kubernetes_manifest" "karpenter_node_class" {

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -823,7 +823,7 @@ resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
     Stack     = "SSM"
   })
   lifecycle {
-    ignore_changes = [ all ]
+    ignore_changes = [ value ]
   }
 }
 
@@ -854,7 +854,7 @@ resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
     Stack     = "SSM"
   })
   lifecycle {
-    ignore_changes = [ all ]
+    ignore_changes = [ value ]
   }
 }
 
@@ -909,7 +909,7 @@ resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
     Stack     = "SSM"
   })
   lifecycle {
-    ignore_changes = [ all ]
+    ignore_changes = [ value ]
   }
 }
 


### PR DESCRIPTION
## Purpose

- Modify existing health check endpoints with new SSM parameter name: `/unity/unity/dev/component/{deployment}`
- Define lifecycle meta-argument to ignore parameter value changes 

## Proposed Changes

- [ADD] SSM parameters: /unity/unity/dev/component/{deployment}/airflow-ui, /unity/unity/dev/component/{deployment}/airflow-api, /unity/unity/dev/component/{deployment}/ogc-api

## Issues

- #127 - Expose SPS health check endpoints

## Testing

Deployed to `unity-venue-dev` and reviewed SSM Parameters. The following parameters were created:

- `/unity/unity/dev/component/nikki/airflow-api`
- `/unity/unity/dev/component/nikki/airflow-ui`
- `/unity/unity/dev/component/nikki/ogc-api`

Reviewed the content of each new parameter and confirmed that SSM parameter string can be loaded into correctly formatted JSON:

```bash
# Airflow UI: 
{
  "componentName": "Airflow UI",
  "healthCheckUrl": "http://k8s-airflow-airflowi-xxx.com:5000/health",
  "landingPageUrl": "http://k8s-airflow-airflowi-xxx.com:5000"
}

# Airflow API: 
{
  "componentName": "Airflow API",
  "healthCheckUrl": "http://k8s-airflow-airflowi-xxx.com:5000/api/v1/health",
  "landingPageUrl": "http://k8s-airflow-airflowi-xxx.com:5000/api/v1"
}

# OGC API: 
{
  "componentName": "OGC API",
  "healthCheckUrl": "http://k8s-airflow-ogcproce-xxx.com:5001/health",
  "landingPageUrl": "http://k8s-airflow-ogcproce-xxx.com:5001"
}
```

*Note:* URLs are shortened for readability.
