### PR TITLE
Add counter to SSM parameter names for health check endpoints

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -809,7 +809,7 @@ resource "aws_ssm_parameter" "airflow_ui_url" {
 }
 
 resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
-  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, "airflow-ui"])))
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, local.counter, "airflow-ui"])))
   description = "The URL of the Airflow UI."
   type        = "String"
   value = jsonencode({
@@ -840,7 +840,7 @@ resource "aws_ssm_parameter" "airflow_api_url" {
 }
 
 resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
-  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, "airflow-api"])))
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, local.counter, "airflow-api"])))
   description = "The URL of the Airflow REST API."
   type        = "String"
   value = jsonencode({
@@ -895,7 +895,7 @@ resource "aws_ssm_parameter" "ogc_processes_api_url" {
 }
 
 resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
-  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, "ogc-api"])))
+  name        = format("/%s", join("/", compact(["", var.project, var.project, var.venue, "component", var.deployment_name, local.counter, "ogc-api"])))
   description = "The URL of the OGC Processes REST API."
   type        = "String"
   value = jsonencode({


### PR DESCRIPTION
## Purpose

- Modify existing health check endpoints with new SSM parameter name: `/unity/unity/dev/component/{deployment}/{counter}`

## Proposed Changes

- [ADD] SSM parameters: /unity/unity/dev/component/{deployment}/airflow-ui, /unity/unity/dev/component/{deployment}/airflow-api, /unity/unity/dev/component/{deployment}/ogc-api

## Issues

- #127 - Expose SPS health check endpoints

## Testing

Deployed to `unity-venue-dev` and reviewed SSM Parameters. The following parameters were created:

- `/unity/unity/dev/component/nikki/1/airflow-api`
- `/unity/unity/dev/component/nikki/1/airflow-ui`
- `/unity/unity/dev/component/nikki/1/ogc-api`

Reviewed the content of each new parameter and confirmed that SSM parameter string can be loaded into correctly formatted JSON:

```bash
# Airflow UI: 
{
  "componentName": "Airflow UI",
  "healthCheckUrl": "http://k8s-airflow-airflowi-xxx.com:5000/health",
  "landingPageUrl": "http://k8s-airflow-airflowi-xxx.com:5000"
}

# Airflow API: 
{
  "componentName": "Airflow API",
  "healthCheckUrl": "http://k8s-airflow-airflowi-xxx.com:5000/api/v1/health",
  "landingPageUrl": "http://k8s-airflow-airflowi-xxx.com:5000/api/v1"
}

# OGC API: 
{
  "componentName": "OGC API",
  "healthCheckUrl": "http://k8s-airflow-ogcproce-xxx.com:5001/health",
  "landingPageUrl": "http://k8s-airflow-ogcproce-xxx.com:5001"
}
```

*Note:* URLs are shortened for readability.
