### PR TITLE
Fix the integration tests after enabling SSL

### DIFF
--- a/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
+++ b/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
@@ -47,6 +47,7 @@ def trigger_dag(airflow_api_url, airflow_api_auth, venue):
         f"{airflow_api_url}/api/v1/dags/{DAG_ID}/dagRuns",
         auth=airflow_api_auth,
         json={"conf": {"cwl_workflow": f"{cwl_workflow}", "cwl_args": f"{cwl_args}"}},
+        # nosec
         verify=False,
     )
     return response
@@ -77,6 +78,7 @@ def poll_dag_run(response, airflow_api_url, airflow_api_auth):
     dag_run_response = requests.get(
         f"""{airflow_api_url}/api/v1/dags/{dag_json["dag_id"]}/dagRuns/{dag_json["dag_run_id"]}""",
         auth=airflow_api_auth,
+        # nosec
         verify=False,
     )
     assert dag_run_response.status_code == 200, f"Expected status code 200, but got {response.status_code}"

--- a/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
+++ b/unity-test/system/integration/step_defs/test_sbg_preprocess_workflow.py
@@ -47,6 +47,7 @@ def trigger_dag(airflow_api_url, airflow_api_auth, venue):
         f"{airflow_api_url}/api/v1/dags/{DAG_ID}/dagRuns",
         auth=airflow_api_auth,
         json={"conf": {"cwl_workflow": f"{cwl_workflow}", "cwl_args": f"{cwl_args}"}},
+        verify=False,
     )
     return response
 
@@ -76,6 +77,7 @@ def poll_dag_run(response, airflow_api_url, airflow_api_auth):
     dag_run_response = requests.get(
         f"""{airflow_api_url}/api/v1/dags/{dag_json["dag_id"]}/dagRuns/{dag_json["dag_run_id"]}""",
         auth=airflow_api_auth,
+        verify=False,
     )
     assert dag_run_response.status_code == 200, f"Expected status code 200, but got {response.status_code}"
     json = dag_run_response.json()


### PR DESCRIPTION
## Purpose

- Using SSL for the SPS endpoints broke the integration tests, because the test client cannot make a valid HTTP request since the endpoint URL does not match the one in the SSL certificate. This PR instructs the client to ignore certificate validation when making the request.

## Proposed Changes

- [CHANGE] The integration tests will use verify=False when making HTTPS requests (GET or POST)

## Issues

- https://github.com/unity-sds/unity-sps/issues/128

## Testing

- Executed the integration test manually on this branch, it succeeded
