### PR TITLE
Add Ops venue to smoke tests

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -97,7 +97,7 @@ jobs:
         dev_status=${{ steps.mcp_venue_dev_smoke_tests.outcome }}
         test_status=${{ steps.mcp_venue_test_smoke_tests.outcome }}
         sbg_dev_status=${{ steps.mcp_sbg_dev_smoke_tests.outcome }}
-        ops_status = ${{ steps.mcp_venue_ops_smoke_tests.outcome }}
+        ops_status=${{ steps.mcp_venue_ops_smoke_tests.outcome }}
         echo "Dev Smoke Tests: $dev_status"
         echo "Test Smoke Tests: $test_status"
         echo "SBG Dev Smoke Tests: $sbg_dev_status"

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -68,17 +68,16 @@ jobs:
         --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_AIRFLOW_ENDPOINT || vars.MCP_VENUE_TEST_AIRFLOW_ENDPOINT }} \
         --ogc-processes-endpoint=${{ github.event.inputs.MCP_VENUE_TEST_OGC_PROCESSES_ENDPOINT || vars.MCP_VENUE_TEST_OGC_PROCESSES_ENDPOINT }}
 
-# Temporary: comment out checks on MCP venue Ops until the SPS is redeployed
-#    - name: MCP Venue Ops - Smoke tests
-#      id: mcp_venue_ops_smoke_tests
-#      env:
-#        AIRFLOW_WEBSERVER_PASSWORD: ${{ secrets.MCP_VENUE_OPS_AIRFLOW_WEBSERVER_PASSWORD }}
-#      continue-on-error: true
-#      run: |
-#        pytest -vv --gherkin-terminal-reporter \
-#        unity-test/system/smoke/step_defs/test_airflow_api_health.py \
-#        --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_OPS_AIRFLOW_ENDPOINT || vars.MCP_VENUE_OPS_AIRFLOW_ENDPOINT }} \
-#        --ogc-processes-endpoint=${{ github.event.inputs.MCP_VENUE_OPS_OGC_PROCESSES_ENDPOINT || vars.MCP_VENUE_OPS_OGC_PROCESSES_ENDPOINT }}
+    - name: MCP Venue Ops - Smoke tests
+      id: mcp_venue_ops_smoke_tests
+      env:
+        AIRFLOW_WEBSERVER_PASSWORD: ${{ secrets.MCP_VENUE_OPS_AIRFLOW_WEBSERVER_PASSWORD }}
+      continue-on-error: true
+      run: |
+        pytest -vv --gherkin-terminal-reporter \
+        unity-test/system/smoke/ \
+        --airflow-endpoint=${{ github.event.inputs.MCP_VENUE_OPS_AIRFLOW_ENDPOINT || vars.MCP_VENUE_OPS_AIRFLOW_ENDPOINT }} \
+        --ogc-processes-endpoint=${{ github.event.inputs.MCP_VENUE_OPS_OGC_PROCESSES_ENDPOINT || vars.MCP_VENUE_OPS_OGC_PROCESSES_ENDPOINT }}
 
     - name: MCP SBG DEV - Smoke tests
       id: mcp_sbg_dev_smoke_tests
@@ -98,11 +97,15 @@ jobs:
         dev_status=${{ steps.mcp_venue_dev_smoke_tests.outcome }}
         test_status=${{ steps.mcp_venue_test_smoke_tests.outcome }}
         sbg_dev_status=${{ steps.mcp_sbg_dev_smoke_tests.outcome }}
+        ops_status = ${{ steps.mcp_venue_ops_smoke_tests.outcome }}
         echo "Dev Smoke Tests: $dev_status"
         echo "Test Smoke Tests: $test_status"
         echo "SBG Dev Smoke Tests: $sbg_dev_status"
+        echo "Ops Smoke Tests: $ops_status"
 
-        if [ "$dev_status" != "success" ] || [ "$test_status" != "success" ] || [ "$sbg_dev_status" != "success" ]; then
+        if [ "$dev_status" != "success" ] || [ "$test_status" != "success" ] \
+                                          || [ "$sbg_dev_status" != "success" ] \
+                                          || [ "$ops_status" != "success" ]; then
           echo "One or more smoke tests failed."
           if [ "$dev_status" != "success" ]; then
             echo "MCP Venue Dev Smoke Tests failed."
@@ -112,6 +115,9 @@ jobs:
           fi
           if [ "$sbg_dev_status" != "success" ]; then
             echo "MCP Venue SBG Dev Smoke Tests failed."
+          fi
+          if [ "$ops_status" != "success" ]; then
+            echo "MCP Venue Ops Smoke Tests failed."
           fi
           exit 1
         else


### PR DESCRIPTION
## Purpose

- This PR adds the Ops venue endpoints to those checked by the smoke tests

## Proposed Changes

- [ADD] Ops venue endpoints to smoke tests

## Issues

- https://github.com/unity-sds/unity-sps/issues/122)

## Testing

- Verified that smoke tests using the Ops venue endpoints succeed with this branch
