### PR TITLE
Change the DAGs to use "sps" for the pods namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,9 +212,10 @@ $RECYCLE.BIN/
 # Local .terraform directories
 **/.terraform/*
 
-# .tfstate files
+# Terraform files
 *.tfstate
 *.tfstate.*
+**.hcl
 
 # Crash log files
 crash.log

--- a/airflow/dags/busybox.py
+++ b/airflow/dags/busybox.py
@@ -16,7 +16,7 @@ from airflow import DAG
 POD_TEMPLATE_FILE = "/opt/airflow/dags/docker_cwl_pod.yaml"
 
 # The Kubernetes namespace within which the Pod is run (it must already exist)
-POD_NAMESPACE = "airflow"
+POD_NAMESPACE = "sps"
 
 # The path of the working directory where the CWL workflow is executed
 # (aka the starting directory for cwl-runner).

--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -23,7 +23,7 @@ from unity_sps_utils import SpsKubernetesPodOperator, get_affinity
 from airflow import DAG
 
 # The Kubernetes namespace within which the Pod is run (it must already exist)
-POD_NAMESPACE = "airflow"
+POD_NAMESPACE = "sps"
 POD_LABEL = "cwl_task"
 SPS_DOCKER_CWL_IMAGE = "ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.1.0"
 

--- a/airflow/dags/karpenter_test.py
+++ b/airflow/dags/karpenter_test.py
@@ -5,7 +5,7 @@ from unity_sps_utils import get_affinity
 
 from airflow import DAG
 
-POD_NAMESPACE = "airflow"
+POD_NAMESPACE = "sps"
 POD_LABEL = "karpenter_test_task"
 
 default_args = {

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_dag.py
@@ -16,7 +16,7 @@ from airflow import DAG
 POD_TEMPLATE_FILE = "/opt/airflow/dags/docker_cwl_pod.yaml"
 
 # The Kubernetes namespace within which the Pod is run (it must already exist)
-POD_NAMESPACE = "airflow"
+POD_NAMESPACE = "sps"
 
 # The path of the working directory where the CWL workflow is executed
 # (aka the starting directory for cwl-runner).

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -21,7 +21,7 @@ from unity_sps_utils import get_affinity
 from airflow import DAG
 
 # The Kubernetes namespace within which the Pod is run (it must already exist)
-POD_NAMESPACE = "airflow"
+POD_NAMESPACE = "sps"
 POD_LABEL = "sbg_task"
 SPS_DOCKER_CWL_IMAGE = "ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.1.0"
 

--- a/airflow/dags/sbg_preprocess_cwl_dag.py
+++ b/airflow/dags/sbg_preprocess_cwl_dag.py
@@ -15,7 +15,7 @@ from unity_sps_utils import get_affinity
 from airflow import DAG
 
 # The Kubernetes namespace within which the Pod is run (it must already exist)
-POD_NAMESPACE = "airflow"
+POD_NAMESPACE = "sps"
 POD_LABEL = "sbg_preprocess_task"
 SPS_DOCKER_CWL_IMAGE = "ghcr.io/unity-sds/unity-sps/sps-docker-cwl:2.1.0"
 


### PR DESCRIPTION
## Purpose

- This PR changes the namespace used by the kubernetes-pod-operator from "airflow" to "sps" to be compatible with the latest Terraform changes

## Proposed Changes

- [CHANGE] "kubernetes-pod-operator" namespace from "airflow" to "sps"

## Issues

- Closed PR: https://github.com/unity-sds/unity-sps/pull/184

## Testing

- Before the change, DAGs were failing
- After the change, the "cwl_dag", "karpenter_test" and "sbg_preprocess_cwl_dag" are succeding
