### PR TITLE
Marking tasks as "setup" and "teardown" in multiple DAGs.

### DIFF
--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -201,4 +201,4 @@ cleanup_task = PythonOperator(
     task_id="Cleanup", python_callable=cleanup, dag=dag, trigger_rule=TriggerRule.ALL_DONE
 )
 
-chain(setup_task, cwl_task, cleanup_task)
+chain(setup_task.as_setup(), cwl_task, cleanup_task.as_teardown(setups=setup_task))

--- a/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
+++ b/airflow/dags/sbg_L1_to_L2_e2e_cwl_step_by_step_dag.py
@@ -573,9 +573,9 @@ cleanup_task = PythonOperator(
 )
 
 chain(
-    setup_task,
+    setup_task.as_setup(),
     preprocess_task,
     [isofit_task, reflect_correct_task],
     [resample_task, frcover_task],
-    cleanup_task,
+    cleanup_task.as_teardown(setups=setup_task),
 )

--- a/airflow/dags/sbg_preprocess_cwl_dag.py
+++ b/airflow/dags/sbg_preprocess_cwl_dag.py
@@ -140,5 +140,4 @@ cleanup_task = PythonOperator(
     task_id="Cleanup", python_callable=cleanup, dag=dag, trigger_rule=TriggerRule.ALL_DONE
 )
 
-
-setup_task >> cwl_task >> cleanup_task
+setup_task.as_setup() >> cwl_task >> cleanup_task.as_teardown(setups=setup_task)


### PR DESCRIPTION
## Purpose

- This PR rectifies the status of a DAG Run to be "failed" if the main worker Task fails, even if the last "cleanup" Task succeeds.

## Proposed Changes

- [CHANGE] Mark the current "setup_task" and "cleanup_task" in several exiting DAGs as the Airflow "setup" and "teardown" Tasks, so that the exit status of the "cleanup_task" is disregarded when setting the final global state of the DAG run.

## Issues

- https://github.com/unity-sds/unity-sps/issues/189

## Testing

- Tested using the CWL DAG executing the simple "echo message" workflow. Verified that the status of the DAG run is set depending on the status of the middle "cwl_task" (see picture), independently on the last "cleanup_task" which always succeeds. See picture.
- 
<img width="302" alt="Screenshot 2024-08-19 at 05 31 07" src="https://github.com/user-attachments/assets/0eeef43a-7f6b-4dfc-8b3b-dd62f7a0476d">



