### PR TITLE
186 ecr cwl dag

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -13,6 +13,7 @@ env:
   TAG: ${{ github.event.inputs.tag }}
   SPS_AIRFLOW: ${{ github.repository }}/sps-airflow
   SPS_DOCKER_CWL: ${{ github.repository }}/sps-docker-cwl
+  SPS_DOCKER_CWL_ECR: ${{ github.repository }}/sps-docker-cwl-ecr
 
 jobs:
   build-sps-airflow:
@@ -60,4 +61,27 @@ jobs:
           file: airflow/docker/cwl/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.SPS_DOCKER_CWL }}:${{ env.TAG }}
+          labels: ${{ steps.metascheduler.outputs.labels }}
+  build-sps-docker-cwl-ecr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for SPS Docker CWL image
+        id: metascheduler
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.SPS_DOCKER_CWL_ECR }}
+      - name: Build and push SPS Docker CWL ECR image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./airflow/docker/cwl_ecr
+          file: airflow/docker/cwl_ecr/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.SPS_DOCKER_CWL_ECR }}:${{ env.TAG }}
           labels: ${{ steps.metascheduler.outputs.labels }}

--- a/airflow/dags/cwl_dag_ecr.py
+++ b/airflow/dags/cwl_dag_ecr.py
@@ -1,0 +1,215 @@
+"""
+DAG to execute a generic CWL workflow.
+
+The Airflow KubernetesPodOperator starts a Docker container that includes the Docker engine and the CWL libraries.
+The "cwl-runner" tool is invoked to execute the CWL workflow.
+Parameter cwl_workflow: the URL of the CWL workflow to execute.
+Parameter args_as_json: JSON string contained the specific values for the workflow specific inputs.
+"""
+
+import json
+import logging
+import os
+import shutil
+from datetime import datetime
+
+from airflow.models import Variable
+from airflow.models.baseoperator import chain
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator, get_current_context
+from airflow.utils.trigger_rule import TriggerRule
+from kubernetes.client import models as k8s
+from unity_sps_utils import SpsKubernetesPodOperator, get_affinity
+
+from airflow import DAG
+
+# The Kubernetes namespace within which the Pod is run (it must already exist)
+POD_NAMESPACE = "sps"
+POD_LABEL = "cwl_task"
+SPS_DOCKER_CWL_IMAGE = "ghcr.io/unity-sds/unity-sps/sps-docker-cwl-ecr:latest"
+
+NODE_POOL_DEFAULT = "airflow-kubernetes-pod-operator"
+NODE_POOL_HIGH_WORKLOAD = "airflow-kubernetes-pod-operator-high-workload"
+
+# The path of the working directory where the CWL workflow is executed
+# (aka the starting directory for cwl-runner).
+# This is fixed to the EFS /scratch directory in this DAG.
+WORKING_DIR = "/scratch"
+
+# default parameters
+DEFAULT_CWL_WORKFLOW = (
+    "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/186-ecr-cwl-dag/demos/echo_message_ecr.cwl"
+)
+DEFAULT_CWL_ARGUMENTS = json.dumps({"message": "Hello Unity"})
+
+# KPO container requirements
+CONTAINER_RESOURCES = k8s.V1ResourceRequirements(
+    requests={
+        "memory": "{{ params.request_memory }}",
+        "cpu": "{{ params.request_cpu }} ",
+        "ephemeral-storage": "{{ params.request_storage }} ",
+    }
+)
+
+# Default DAG configuration
+dag_default_args = {
+    "owner": "unity-sps",
+    "depends_on_past": False,
+    "start_date": datetime.utcfromtimestamp(0),
+}
+
+dag = DAG(
+    dag_id="cwl_dag_ecr",
+    description="CWL DAG ECR",
+    tags=["CWL", "ECR"],
+    is_paused_upon_creation=False,
+    catchup=False,
+    schedule=None,
+    max_active_runs=10,
+    max_active_tasks=30,
+    default_args=dag_default_args,
+    params={
+        "cwl_workflow": Param(
+            DEFAULT_CWL_WORKFLOW, type="string", title="CWL workflow", description="The CWL workflow URL"
+        ),
+        "cwl_args": Param(
+            DEFAULT_CWL_ARGUMENTS,
+            type="string",
+            title="CWL workflow parameters",
+            description=("The job parameters encoded as a JSON string," "or the URL of a JSON or YAML file"),
+        ),
+        "request_memory": Param(
+            "4Gi",
+            type="string",
+            enum=["8Gi", "16Gi", "32Gi", "64Gi", "128Gi", "256Gi"],
+            title="Docker container memory",
+        ),
+        "request_cpu": Param(
+            "4",
+            type="string",
+            enum=["2", "4", "8", "16", "32"],
+            title="Docker container CPU",
+        ),
+        "request_storage": Param(
+            "10Gi",
+            type="string",
+            enum=["10Gi", "50Gi", "100Gi", "200Gi", "300Gi"],
+            title="Docker container storage",
+        ),
+    },
+)
+
+
+def setup(ti=None, **context):
+    """
+    Task that creates the working directory on the shared volume
+    and parses the input parameter values.
+    """
+    context = get_current_context()
+    dag_run_id = context["dag_run"].run_id
+    local_dir = f"/shared-task-data/{dag_run_id}"
+    logging.info(f"Creating directory: {local_dir}")
+    os.makedirs(local_dir, exist_ok=True)
+    logging.info(f"Created directory: {local_dir}")
+
+    # select the node pool based on what resources were requested
+    node_pool = NODE_POOL_DEFAULT
+    storage = context["params"]["request_storage"]  # 100Gi
+    storage = int(storage[0:-2])  # 100
+    memory = context["params"]["request_memory"]  # 32Gi
+    memory = int(memory[0:-2])  # 32
+    cpu = int(context["params"]["request_cpu"])  # 8
+
+    logging.info(f"Requesting storage={storage}Gi memory={memory}Gi CPU={cpu}")
+    if (storage > 30) or (memory > 32) or (cpu > 8):
+        node_pool = NODE_POOL_HIGH_WORKLOAD
+    logging.info(f"Selecting node pool={node_pool}")
+    ti.xcom_push(key="node_pool", value=node_pool)
+    
+    # grab ECR URI from airflow variable\
+    ecr_uri = Variable.get("cwl_dag_ecr_uri")
+    cwl_dag_args = {
+        "message": context["params"]["cwl_args"],
+        "cwltool:overrides": {
+            context["params"]["cwl_workflow"]: {
+                "requirements": {
+                    "DockerRequirement": {
+                        "dockerPull": ecr_uri
+                    }
+                }
+            }
+        }
+    }
+    logging.info(f"CWL DAG arguments: {cwl_dag_args['message']}")
+    logging.info(f"CWL DAG ECR image: {cwl_dag_args['cwltool:overrides']}")
+    ti.xcom_push(key="cwl_dag_arguments", value=json.dumps(cwl_dag_args))
+    
+    # save ECR login URL
+    ecr_login = ecr_uri.split("/")[0]
+    logging.info(f"ECR Login: {ecr_login}")
+    ti.xcom_push(key="ecr_login", value=ecr_login)
+
+
+setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag)
+
+cwl_task = SpsKubernetesPodOperator(
+    retries=0,
+    task_id="cwl_task",
+    namespace=POD_NAMESPACE,
+    name="cwl-task-pod",
+    image=SPS_DOCKER_CWL_IMAGE,
+    service_account_name="airflow-worker",
+    in_cluster=True,
+    get_logs=True,
+    startup_timeout_seconds=1800,
+    arguments=[
+        "{{ params.cwl_workflow }}", 
+        "{{ ti.xcom_pull(task_ids='Setup', key='cwl_dag_arguments') }}",
+        "{{ ti.xcom_pull(task_ids='Setup', key='ecr_login') }}"
+        ],
+    container_security_context={"privileged": True},
+    container_resources=CONTAINER_RESOURCES,
+    container_logs=True,
+    volume_mounts=[
+        k8s.V1VolumeMount(name="workers-volume", mount_path=WORKING_DIR, sub_path="{{ dag_run.run_id }}")
+    ],
+    volumes=[
+        k8s.V1Volume(
+            name="workers-volume",
+            persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="airflow-kpo"),
+        )
+    ],
+    dag=dag,
+    node_selector={"karpenter.sh/nodepool": "{{ti.xcom_pull(task_ids='Setup', key='node_pool')}}"},
+    labels={"app": POD_LABEL},
+    annotations={"karpenter.sh/do-not-disrupt": "true"},
+    # note: 'affinity' cannot yet be templated
+    affinity=get_affinity(
+        capacity_type=["spot"],
+        # instance_type=["t3.2xlarge"],
+        anti_affinity_label=POD_LABEL,
+    ),
+    on_finish_action="keep_pod",
+    is_delete_operator_pod=False,
+)
+
+
+def cleanup(**context):
+    """
+    Tasks that deletes all data shared between Tasks
+    from the Kubernetes PersistentVolume
+    """
+    dag_run_id = context["dag_run"].run_id
+    local_dir = f"/shared-task-data/{dag_run_id}"
+    if os.path.exists(local_dir):
+        shutil.rmtree(local_dir)
+        logging.info(f"Deleted directory: {local_dir}")
+    else:
+        logging.info(f"Directory does not exist, no need to delete: {local_dir}")
+
+
+cleanup_task = PythonOperator(
+    task_id="Cleanup", python_callable=cleanup, dag=dag, trigger_rule=TriggerRule.ALL_DONE
+)
+
+chain(setup_task, cwl_task, cleanup_task)

--- a/airflow/docker/cwl_ecr/Dockerfile
+++ b/airflow/docker/cwl_ecr/Dockerfile
@@ -1,0 +1,25 @@
+# docker:dind Dockerfile: https://github.com/docker-library/docker/blob/master/Dockerfile-dind.template
+# FROM docker:dind
+FROM docker:25.0.3-dind
+
+# install Python
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN apk add gcc musl-dev linux-headers python3-dev
+RUN apk add --no-cache python3 py3-pip
+RUN apk add vim
+
+# install CWL libraries
+RUN mkdir /usr/share/cwl \
+    && cd /usr/share/cwl \
+    && python -m venv venv \
+    && source venv/bin/activate \
+    && pip install cwltool cwl-runner docker boto3 awscli
+
+# install nodejs to parse Javascript in CWL files
+RUN apk add --no-cache nodejs npm
+
+# script to execute a generic CWL workflow with arguments
+COPY docker_cwl_ecr_entrypoint.sh /usr/share/cwl/docker_cwl_ecr_entrypoint.sh
+
+WORKDIR /usr/share/cwl
+ENTRYPOINT ["/usr/share/cwl/docker_cwl_ecr_entrypoint.sh"]

--- a/airflow/docker/cwl_ecr/docker_cwl_ecr_entrypoint.sh
+++ b/airflow/docker/cwl_ecr/docker_cwl_ecr_entrypoint.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# Script to execute a CWL workflow that includes Docker containers
+# The Docker engine is started before the CWL execution, and stopped afterwards.
+# $1: the CWL workflow URL
+#     (example: https://github.com/unity-sds/sbg-workflows/blob/main/L1-to-L2-e2e.cwl)
+# $2: a) the CWL job parameters as a JSON formatted string
+#        (example: { "name": "John Doe" })
+#  OR b) the URL of a YAML or JSON file containing the job parameters
+#        (example: https://github.com/unity-sds/sbg-workflows/blob/main/L1-to-L2-e2e.dev.yml)
+# $3: the ECR login URL where the AWS account ID and region are specific to the Airflow installation
+#        (example: <aws_account_id>.dkr.ecr.<region>.amazonaws.com)
+# $4: optional path to an output JSON file that needs to be shared as Airflow "xcom" data
+
+# Must be the same as the path of the Persistent Volume mounted by the Airflow KubernetesPodOperator
+# that executes this script
+WORKING_DIR="/scratch"
+
+set -ex
+
+# command line arguments
+cwl_workflow=$1
+job_args=$2
+ecr_login=$3
+json_output=$4
+
+# create working directory if it doesn't exist
+mkdir -p "$WORKING_DIR"
+cd $WORKING_DIR
+
+# switch between the 2 cases a) and b) for job_args
+# remove arguments from previous tasks
+rm -f ./job_args.json
+if [ "$job_args" = "${job_args#{}" ]
+then
+  # job_args does NOT start with '{'
+  echo "Using job arguments from URL: $job_args"
+else
+  # job_args starts with '{'
+  echo "$job_args" > ./job_args.json
+  echo "Using job arguments from JSON string:" && cat ./job_args.json
+  job_args="./job_args.json"
+fi
+echo "Executing the CWL workflow: $cwl_workflow with json arguments: $job_args and working directory: $WORKING_DIR"
+echo "JSON XCOM output: ${json_output}"
+
+# Start Docker engine
+dockerd &> dockerd-logfile &
+
+# Wait until Docker engine is running
+# Loop until 'docker version' exits with 0.
+until docker version > /dev/null 2>&1
+do
+  sleep 1
+done
+
+# Activate Python virtual environments for executables
+. /usr/share/cwl/venv/bin/activate
+
+# Log into AWS ECR repository
+IFS=. read account_id dkr ecr aws_region amazonaws com <<EOF 
+${ecr_login} 
+EOF
+aws ecr get-login-password --region $aws_region | docker login --username AWS --password-stdin $ecr_login
+echo "Logged into: $ecr_login"
+
+# Execute CWL workflow in working directory
+# List contents when done
+pwd
+ls -lR
+cwl-runner --tmp-outdir-prefix "$PWD"/ --no-read-only "$cwl_workflow" "$job_args"
+ls -lR
+
+# Optionally, save the requested output file to a location
+# where it will be picked up by the Airflow XCOM mechanism
+# Note: the content of the file MUST be valid JSON or XCOM will fail.
+if [ ! -z "${json_output}" -a "${json_output}" != " " ]; then
+  mkdir -p /airflow/xcom/
+  cp ${json_output} /airflow/xcom/return.json
+fi
+
+deactivate
+
+# Stop Docker engine
+pkill -f dockerd


### PR DESCRIPTION
## Purpose

- Demonstrate the use of ECR within an Airflow DAG so that the end user can use their own private ECR repository in the execution of a CWL DAG.

## Proposed Changes

- [ADD] Container image and Python script that facilitates the use of AWS ECR in CWL DAGs.

## Issues

- #186 

## Testing

- Deployed container image to GHCR and copied DAG definition to development Airflow installation.
- Ran DAG: `cwl_dag_ecr` to confirm the DAG will pull the AWS ECR URI and complete successfully.

Logs (truncated to only include success details)

```bash
[2024-08-27, 13:38:48 UTC] {pod_manager.py:468} INFO - [base] + aws ecr get-login-password --region xxx
[2024-08-27, 13:38:49 UTC] {pod_manager.py:468} INFO - [base] + docker login --username AWS --password-stdin xxx.dkr.ecr.xxx.amazonaws.com
[2024-08-27, 13:38:49 UTC] {pod_manager.py:468} INFO - [base] WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
[2024-08-27, 13:38:49 UTC] {pod_manager.py:468} INFO - [base] Configure a credential helper to remove this warning. See
[2024-08-27, 13:38:49 UTC] {pod_manager.py:468} INFO - [base] https://docs.docker.com/engine/reference/commandline/login/#credentials-store
[2024-08-27, 13:38:49 UTC] {pod_manager.py:468} INFO - [base] Login Succeeded
[2024-08-27, 13:38:49 UTC] {pod_manager.py:468} INFO - [base] Logged into: xxx.dkr.ecr.xxx.amazonaws.com
...
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] INFO /usr/share/cwl/venv/bin/cwl-runner 3.1.20240708091337
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] Error: No such object: xxx.dkr.ecr.xxx.amazonaws.com/unity-nikki-1-dev-sps-busybox
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] INFO ['docker', 'pull', 'xxx.dkr.ecr.xxx.amazonaws.com/unity-nikki-1-dev-sps-busybox']
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] Using default tag: latest
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] latest: Pulling from unity-nikki-1-dev-sps-busybox
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] xxx: Pulling fs layer
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] xxx: Verifying Checksum
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] xxx: Download complete
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] xxx: Pull complete
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] Digest: sha256:xxx
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] Status: Downloaded newer image for xxx.dkr.ecr.xxx.amazonaws.com/unity-nikki-1-dev-sps-busybox:latest
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] xxx.dkr.ecr.xxx.amazonaws.com/unity-nikki-1-dev-sps-busybox:latest
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base] INFO [job echo_message_ecr.cwl] /scratch/z6o_f23f$ docker \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     run \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     -i \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --mount=type=bind,source=/scratch/z6o_f23f,target=/wyvDSa \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --mount=type=bind,source=/tmp/dpd5rnoj,target=/tmp \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --workdir=/wyvDSa \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --net=none \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --log-driver=none \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --user=0:0 \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --rm \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --cidfile=/tmp/aulc0ggb/20240827133851-877513.cid \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --env=TMPDIR=/tmp \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     --env=HOME=/wyvDSa \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     xxx.dkr.ecr.xxx.amazonaws.com/unity-nikki-1-dev-sps-busybox \
[2024-08-27, 13:38:51 UTC] {pod_manager.py:468} INFO - [base]     echo \
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]     https://github.com/unity-sds/unity-sps-workflows/blob/186-ecr-cwl-dag/demos/echo_message_ecr.yaml > /scratch/z6o_f23f/echo_message.txt
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base] INFO [job echo_message_ecr.cwl] completed success
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base] {
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]     "the_output": {
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]         "location": "file:///scratch/echo_message.txt",
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]         "basename": "echo_message.txt",
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]         "class": "File",
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]         "checksum": "sha1$78daed7b0a376de5fe9f87ef75249dc53b13f9fa",
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]         "size": 98,
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]         "path": "/scratch/echo_message.txt"
[2024-08-27, 13:38:52 UTC] {pod_manager.py:468} INFO - [base]     }
[2024-08-27, 13:38:53 UTC] {pod_manager.py:468} INFO - [base] INFO Final process status is success
```
