### PR TITLE
renaming some ssm params having to do with network

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/data.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/data.tf
@@ -9,7 +9,7 @@ data "aws_vpc" "cluster_vpc" {
 }
 
 data "aws_ssm_parameter" "subnet_ids" {
-  name = "/unity/cs/account/network/subnet_list"
+  name = "/unity/account/network/subnet_list"
 }
 
 data "kubernetes_namespace" "service_area" {

--- a/terraform-unity/modules/terraform-unity-sps-database/data.tf
+++ b/terraform-unity/modules/terraform-unity-sps-database/data.tf
@@ -3,7 +3,7 @@ data "aws_eks_cluster" "cluster" {
 }
 
 data "aws_ssm_parameter" "subnet_ids" {
-  name = "/unity/cs/account/network/subnet_list"
+  name = "/unity/account/network/subnet_list"
 }
 
 data "aws_security_group" "default" {

--- a/terraform-unity/modules/terraform-unity-sps-karpenter-node-config/data.tf
+++ b/terraform-unity/modules/terraform-unity-sps-karpenter-node-config/data.tf
@@ -7,7 +7,7 @@ data "aws_iam_role" "cluster_iam_role" {
 }
 
 data "aws_ssm_parameter" "subnet_ids" {
-  name = "/unity/cs/account/network/subnet_list"
+  name = "/unity/account/network/subnet_list"
 }
 
 data "aws_ssm_parameter" "al2_eks_optimized_ami" {

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/data.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/data.tf
@@ -5,7 +5,7 @@ data "kubernetes_namespace" "service_area" {
 }
 
 data "aws_ssm_parameter" "subnet_ids" {
-  name = "/unity/cs/account/network/subnet_list"
+  name = "/unity/account/network/subnet_list"
 }
 
 data "aws_db_instance" "db" {


### PR DESCRIPTION
## Purpose

- we are changing
/unity/cs/account/network/subnet_list
/unity/cs/account/network/vpc_id
to
/unity/account/network/subnet_list
/unity/account/network/vpc_id

See also:  https://github.com/unity-sds/unity-cs-infra/pull/98

