### PR TITLE
Adding guards around venue proxy lambda call

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -531,7 +531,7 @@ EOT
 data "aws_lambda_functions" "lambda_check_all" {}
 
 resource "aws_lambda_invocation" "unity_proxy_lambda_invocation" {
-  count = contains(data.aws_lambda_functions.lambda_check_all.function_names,"unity-${var.venue}-httpdproxymanagement") ? 1 : 0
+  count         = contains(data.aws_lambda_functions.lambda_check_all.function_names, "unity-${var.venue}-httpdproxymanagement") ? 1 : 0
   function_name = "unity-${var.venue}-httpdproxymanagement"
   input         = "{}"
   triggers = {

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -528,8 +528,10 @@ EOT
   })
 }
 
+data "aws_lambda_functions" "lambda_check_all" {}
 
 resource "aws_lambda_invocation" "unity_proxy_lambda_invocation" {
+  count = contains(data.aws_lambda_functions.lambda_check_all.function_names,"unity-${var.venue}-httpdproxymanagement") ? 1 : 0
   function_name = "unity-${var.venue}-httpdproxymanagement"
   input         = "{}"
   triggers = {

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/README.md
@@ -33,6 +33,7 @@ No modules.
 | [kubernetes_service.ogc_processes_api](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/service) | resource |
 | [kubernetes_service.redis](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/service) | resource |
 | [aws_db_instance.db](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/db_instance) | data source |
+| [aws_lambda_functions.lambda_check_all](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/lambda_functions) | data source |
 | [aws_secretsmanager_secret_version.db](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_ssm_parameter.subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/ssm_parameter) | data source |
 | [kubernetes_ingress_v1.ogc_processes_api_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/ingress_v1) | data source |

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -309,7 +309,10 @@ EOT
   })
 }
 
+data "aws_lambda_functions" "lambda_check_all" {}
+
 resource "aws_lambda_invocation" "unity_proxy_lambda_invocation" {
+  count         = contains(data.aws_lambda_functions.lambda_check_all.function_names, "unity-${var.venue}-httpdproxymanagement") ? 1 : 0
   function_name = "unity-${var.venue}-httpdproxymanagement"
   input         = "{}"
   triggers = {


### PR DESCRIPTION
## Purpose

- Adding a simple check to verify if the venue proxy lambda is actually available before calling it.

## Proposed Changes

- ADD polling available lambdas before calling proxy lambda

## Issues

- 

## Testing

-  Tested on personal airflow deployment. Verified seeing the following in the terraform logs (with none of the previous lambda invocation errors)
```
module.unity-sps-airflow.data.aws_lambda_functions.lambda_check_all: Reading...
...
module.unity-sps-airflow.data.aws_lambda_functions.lambda_check_all: Read complete after 0s [id=us-west-2]
...
module.unity-sps-airflow.aws_lambda_invocation.unity_proxy_lambda_invocation[0]: Creating...
```