### PR TITLE
Fix ALB lockdown configurations

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/README.md
@@ -42,6 +42,7 @@ No modules.
 | [aws_s3_bucket.airflow_logs](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/s3_bucket) | resource |
 | [aws_security_group.airflow_efs](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/security_group) | resource |
 | [aws_security_group.airflow_ingress_sg](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/security_group) | resource |
+| [aws_security_group.airflow_ingress_sg_internal](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/security_group) | resource |
 | [aws_security_group_rule.airflow_efs](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/security_group_rule) | resource |
 | [aws_ssm_parameter.airflow_api_health_check_endpoint](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.airflow_api_url](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/ssm_parameter) | resource |
@@ -54,6 +55,7 @@ No modules.
 | [helm_release.airflow](https://registry.terraform.io/providers/hashicorp/helm/2.13.1/docs/resources/release) | resource |
 | [helm_release.keda](https://registry.terraform.io/providers/hashicorp/helm/2.13.1/docs/resources/release) | resource |
 | [kubernetes_ingress_v1.airflow_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/ingress_v1) | resource |
+| [kubernetes_ingress_v1.airflow_ingress_internal](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/ingress_v1) | resource |
 | [kubernetes_namespace.keda](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/namespace) | resource |
 | [kubernetes_persistent_volume.airflow_deployed_dags](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/persistent_volume) | resource |
 | [kubernetes_persistent_volume.airflow_kpo](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/persistent_volume) | resource |
@@ -77,6 +79,7 @@ No modules.
 | [aws_ssm_parameter.subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/ssm_parameter) | data source |
 | [aws_vpc.cluster_vpc](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/vpc) | data source |
 | [kubernetes_ingress_v1.airflow_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/ingress_v1) | data source |
+| [kubernetes_ingress_v1.airflow_ingress_internal](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/ingress_v1) | data source |
 | [kubernetes_namespace.service_area](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/namespace) | data source |
 
 ## Inputs

--- a/terraform-unity/modules/terraform-unity-sps-airflow/data.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/data.tf
@@ -25,6 +25,13 @@ data "kubernetes_ingress_v1" "airflow_ingress" {
   }
 }
 
+data "kubernetes_ingress_v1" "airflow_ingress_internal" {
+  metadata {
+    name      = kubernetes_ingress_v1.airflow_ingress_internal.metadata[0].name
+    namespace = data.kubernetes_namespace.service_area.metadata[0].name
+  }
+}
+
 data "aws_db_instance" "db" {
   db_instance_identifier = var.db_instance_identifier
 }

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -548,8 +548,8 @@ resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
   type        = "String"
   value = jsonencode({
     "componentName" : "Airflow UI"
-    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/health"
-    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000"
+    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/health"
+    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000"
   })
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "health-check-endpoints-airflow_ui")
@@ -579,8 +579,8 @@ resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
   type        = "String"
   value = jsonencode({
     "componentName" : "Airflow API"
-    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1/health"
-    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1"
+    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1/health"
+    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/api/v1"
   })
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "health-check-endpoints-airflow_api")

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -414,6 +414,17 @@ resource "aws_security_group" "airflow_ingress_sg" {
   })
 }
 
+resource "aws_security_group" "airflow_ingress_sg_internal" {
+  name        = "${var.project}-${var.venue}-airflow-internal-ingress-sg"
+  description = "SecurityGroup for Airflow LoadBalancer internal ingress"
+  vpc_id      = data.aws_vpc.cluster_vpc.id
+  tags = merge(local.common_tags, {
+    Name      = format(local.resource_name_prefix, "AirflowLBSg")
+    Component = "airflow"
+    Stack     = "airflow"
+  })
+}
+
 #tfsec:ignore:AVD-AWS-0107
 resource "aws_vpc_security_group_ingress_rule" "airflow_ingress_sg_jpl_rule" {
   for_each          = toset(["128.149.0.0/16", "137.78.0.0/16", "137.79.0.0/16"])
@@ -437,7 +448,7 @@ data "aws_security_groups" "venue_proxy_sg" {
 
 resource "aws_vpc_security_group_ingress_rule" "airflow_ingress_sg_proxy_rule" {
   count                        = length(data.aws_security_groups.venue_proxy_sg.ids) > 0 ? 1 : 0
-  security_group_id            = aws_security_group.airflow_ingress_sg.id
+  security_group_id            = aws_security_group.airflow_ingress_sg_internal.id
   description                  = "SecurityGroup ingress rule for venue-services proxy"
   ip_protocol                  = "tcp"
   from_port                    = local.load_balancer_port
@@ -455,6 +466,43 @@ resource "kubernetes_ingress_v1" "airflow_ingress" {
       "alb.ingress.kubernetes.io/subnets"                             = join(",", jsondecode(data.aws_ssm_parameter.subnet_ids.value)["public"])
       "alb.ingress.kubernetes.io/listen-ports"                        = "[{\"HTTP\": ${local.load_balancer_port}}]"
       "alb.ingress.kubernetes.io/security-groups"                     = aws_security_group.airflow_ingress_sg.id
+      "alb.ingress.kubernetes.io/manage-backend-security-group-rules" = "true"
+      "alb.ingress.kubernetes.io/healthcheck-path"                    = "/health"
+    }
+  }
+  spec {
+    ingress_class_name = "alb"
+    rule {
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "airflow-webserver"
+              port {
+                number = 8080
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  wait_for_load_balancer = true
+  depends_on             = [helm_release.airflow]
+}
+
+resource "kubernetes_ingress_v1" "airflow_ingress_internal" {
+  metadata {
+    name      = "airflow-ingress"
+    namespace = data.kubernetes_namespace.service_area.metadata[0].name
+    annotations = {
+      "alb.ingress.kubernetes.io/scheme"                              = "internal"
+      "alb.ingress.kubernetes.io/target-type"                         = "ip"
+      "alb.ingress.kubernetes.io/subnets"                             = join(",", jsondecode(data.aws_ssm_parameter.subnet_ids.value)["private"])
+      "alb.ingress.kubernetes.io/listen-ports"                        = "[{\"HTTP\": ${local.load_balancer_port}}]"
+      "alb.ingress.kubernetes.io/security-groups"                     = aws_security_group.airflow_ingress_sg_internal.id
       "alb.ingress.kubernetes.io/manage-backend-security-group-rules" = "true"
       "alb.ingress.kubernetes.io/healthcheck-path"                    = "/health"
     }
@@ -557,7 +605,7 @@ resource "aws_ssm_parameter" "unity_proxy_airflow_ui" {
       Redirect "/${var.project}/${var.venue}/sps/home"
     </Location>
     <LocationMatch "^/${var.project}/${var.venue}/sps/(.*)$">
-      ProxyPassMatch "http://${data.kubernetes_ingress_v1.airflow_ingress.status[0].load_balancer[0].ingress[0].hostname}:5000/$1"
+      ProxyPassMatch "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/$1"
       ProxyPreserveHost On
       FallbackResource /management/index.html
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -495,7 +495,7 @@ resource "kubernetes_ingress_v1" "airflow_ingress" {
 
 resource "kubernetes_ingress_v1" "airflow_ingress_internal" {
   metadata {
-    name      = "airflow-ingress"
+    name      = "airflow-ingress-internal"
     namespace = data.kubernetes_namespace.service_area.metadata[0].name
     annotations = {
       "alb.ingress.kubernetes.io/scheme"                              = "internal"

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/README.md
@@ -24,6 +24,7 @@ No modules.
 |------|------|
 | [aws_lambda_invocation.unity_proxy_lambda_invocation](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/lambda_invocation) | resource |
 | [aws_security_group.ogc_ingress_sg](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/security_group) | resource |
+| [aws_security_group.ogc_ingress_sg_internal](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/security_group) | resource |
 | [aws_ssm_parameter.ogc_processes_api_health_check_endpoint](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ogc_processes_api_url](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ogc_processes_ui_url](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/resources/ssm_parameter) | resource |
@@ -33,6 +34,7 @@ No modules.
 | [kubernetes_deployment.ogc_processes_api](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/deployment) | resource |
 | [kubernetes_deployment.redis](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/deployment) | resource |
 | [kubernetes_ingress_v1.ogc_processes_api_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/ingress_v1) | resource |
+| [kubernetes_ingress_v1.ogc_processes_api_ingress_internal](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/ingress_v1) | resource |
 | [kubernetes_service.ogc_processes_api](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/service) | resource |
 | [kubernetes_service.redis](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/resources/service) | resource |
 | [aws_db_instance.db](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/db_instance) | data source |
@@ -43,6 +45,7 @@ No modules.
 | [aws_ssm_parameter.subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/ssm_parameter) | data source |
 | [aws_vpc.cluster_vpc](https://registry.terraform.io/providers/hashicorp/aws/5.50.0/docs/data-sources/vpc) | data source |
 | [kubernetes_ingress_v1.ogc_processes_api_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/ingress_v1) | data source |
+| [kubernetes_ingress_v1.ogc_processes_api_ingress_internal](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/ingress_v1) | data source |
 | [kubernetes_namespace.service_area](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/namespace) | data source |
 | [kubernetes_persistent_volume_claim.airflow_deployed_dags](https://registry.terraform.io/providers/hashicorp/kubernetes/2.29.0/docs/data-sources/persistent_volume_claim) | data source |
 

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/data.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/data.tf
@@ -36,3 +36,10 @@ data "kubernetes_ingress_v1" "ogc_processes_api_ingress" {
     namespace = data.kubernetes_namespace.service_area.metadata[0].name
   }
 }
+
+data "kubernetes_ingress_v1" "ogc_processes_api_ingress_internal" {
+  metadata {
+    name      = kubernetes_ingress_v1.ogc_processes_api_ingress_internal.metadata[0].name
+    namespace = data.kubernetes_namespace.service_area.metadata[0].name
+  }
+}

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -297,7 +297,7 @@ resource "kubernetes_ingress_v1" "ogc_processes_api_ingress" {
 
 resource "kubernetes_ingress_v1" "ogc_processes_api_ingress_internal" {
   metadata {
-    name      = "ogc-processes-api-ingress"
+    name      = "ogc-processes-api-ingress-internal"
     namespace = data.kubernetes_namespace.service_area.metadata[0].name
     annotations = {
       "alb.ingress.kubernetes.io/scheme"                              = "internal"

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -217,6 +217,17 @@ resource "aws_security_group" "ogc_ingress_sg" {
   })
 }
 
+resource "aws_security_group" "ogc_ingress_sg_internal" {
+  name        = "${var.project}-${var.venue}-ogc-internal-ingress-sg"
+  description = "SecurityGroup for OGC API LoadBalancer internal ingress"
+  vpc_id      = data.aws_vpc.cluster_vpc.id
+  tags = merge(local.common_tags, {
+    Name      = format(local.resource_name_prefix, "OgcLBSg")
+    Component = "ogc"
+    Stack     = "ogc"
+  })
+}
+
 #tfsec:ignore:AVD-AWS-0107
 resource "aws_vpc_security_group_ingress_rule" "ogc_ingress_sg_jpl_rule" {
   for_each          = toset(["128.149.0.0/16", "137.78.0.0/16", "137.79.0.0/16"])
@@ -240,7 +251,7 @@ data "aws_security_groups" "venue_proxy_sg" {
 
 resource "aws_vpc_security_group_ingress_rule" "ogc_ingress_sg_proxy_rule" {
   count                        = length(data.aws_security_groups.venue_proxy_sg.ids) > 0 ? 1 : 0
-  security_group_id            = aws_security_group.ogc_ingress_sg.id
+  security_group_id            = aws_security_group.ogc_ingress_sg_internal.id
   description                  = "SecurityGroup ingress rule for venue-services proxy"
   ip_protocol                  = "tcp"
   from_port                    = local.load_balancer_port
@@ -284,6 +295,41 @@ resource "kubernetes_ingress_v1" "ogc_processes_api_ingress" {
   wait_for_load_balancer = true
 }
 
+resource "kubernetes_ingress_v1" "ogc_processes_api_ingress_internal" {
+  metadata {
+    name      = "ogc-processes-api-ingress"
+    namespace = data.kubernetes_namespace.service_area.metadata[0].name
+    annotations = {
+      "alb.ingress.kubernetes.io/scheme"                              = "internal"
+      "alb.ingress.kubernetes.io/target-type"                         = "ip"
+      "alb.ingress.kubernetes.io/subnets"                             = join(",", jsondecode(data.aws_ssm_parameter.subnet_ids.value)["private"])
+      "alb.ingress.kubernetes.io/listen-ports"                        = "[{\"HTTP\": ${local.load_balancer_port}}]"
+      "alb.ingress.kubernetes.io/security-groups"                     = aws_security_group.ogc_ingress_sg_internal.id
+      "alb.ingress.kubernetes.io/manage-backend-security-group-rules" = "true"
+      "alb.ingress.kubernetes.io/healthcheck-path"                    = "/health"
+    }
+  }
+  spec {
+    ingress_class_name = "alb"
+    rule {
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = kubernetes_service.ogc_processes_api.metadata[0].name
+              port {
+                number = 80
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  wait_for_load_balancer = true
+}
 
 resource "aws_ssm_parameter" "ogc_processes_ui_url" {
   name        = format("/%s", join("/", compact(["", var.project, var.venue, var.service_area, "processing", "ogc_processes", "ui_url"])))
@@ -338,7 +384,7 @@ resource "aws_ssm_parameter" "unity_proxy_ogc_api" {
       ProxyPassReverse "/"
     </Location>
     <LocationMatch "^/${var.project}/${var.venue}/ogc/(.*)$">
-      ProxyPassMatch "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001/$1"
+      ProxyPassMatch "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5001/$1"
       ProxyPreserveHost On
       FallbackResource /management/index.html
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -361,8 +361,8 @@ resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
   type        = "String"
   value = jsonencode({
     "componentName" : "OGC API"
-    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001/health"
-    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress.status[0].load_balancer[0].ingress[0].hostname}:5001"
+    "healthCheckUrl" : "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5001/health"
+    "landingPageUrl" : "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5001"
   })
   tags = merge(local.common_tags, {
     Name      = format(local.resource_name_prefix, "health-check-endpoints-ogc_processes_api")


### PR DESCRIPTION
## Purpose

- Fixing issues introduced by #201. Namely, adding a new internal ALB for unity services to connect to without leaving the private subnets.

## Proposed Changes

- ADD Additional security group for internal connections
- ADD Additional k8s-driven ingress for internal-only/private-subnet connections
- CHANGE internal venue-services proxy and healthcheck SSM parameters to reference internal endpoints

## Issues

- unity-sds/unity-cs#429

## Testing

- Tested on personal deployment: http://btl-d7-dev-httpd-alb-353487587.us-west-2.elb.amazonaws.com:8080/btl-d7/dev/sps/
  - non-venue-proxy endpoint: http://k8s-sps-airflowi-1c931ef118-1938076165.us-west-2.elb.amazonaws.com:5000/