### PR TITLE
Fix the shared-services/venue-services/airflow proxy request issues

### DIFF
--- a/airflow/helm/values.tmpl.yaml
+++ b/airflow/helm/values.tmpl.yaml
@@ -250,6 +250,8 @@ config:
     encrypt_s3_logs: false
   celery:
     worker_concurrency: 16
+  webserver:
+    enable_proxy_fix: 'True'
 
 dags:
   persistence:

--- a/terraform-unity/modules/terraform-unity-sps-airflow/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/README.md
@@ -69,6 +69,7 @@ No modules.
 | [kubernetes_storage_class.efs](https://registry.terraform.io/providers/hashicorp/kubernetes/2.32.0/docs/resources/storage_class) | resource |
 | [null_resource.remove_keda_finalizers](https://registry.terraform.io/providers/hashicorp/null/3.2.3/docs/resources/resource) | resource |
 | [random_id.airflow_webserver_secret](https://registry.terraform.io/providers/hashicorp/random/3.6.1/docs/resources/id) | resource |
+| [time_sleep.wait_after_ssm](https://registry.terraform.io/providers/hashicorp/time/0.12.1/docs/resources/sleep) | resource |
 | [time_sleep.wait_for_efs_mount_target_dns_propagation](https://registry.terraform.io/providers/hashicorp/time/0.12.1/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/data-sources/caller_identity) | data source |
 | [aws_db_instance.db](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/data-sources/db_instance) | data source |

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -638,8 +638,6 @@ resource "aws_ssm_parameter" "unity_proxy_airflow_ui" {
       ProxyPassMatch "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/$1"
       ProxyPreserveHost On
       FallbackResource /management/index.html
-      RequestHeader setifempty "X-Forwarded-Proto" "http"
-      RequestHeader setifempty "X-Forwarded-Port" expr=%%{SERVER_PORT}
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
       Substitute "s|\"/([^\"]*)|\"/${var.project}/${var.venue}/sps/$1|q"
     </LocationMatch>

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -653,8 +653,8 @@ EOT
 data "aws_lambda_functions" "lambda_check_all" {}
 
 resource "aws_lambda_invocation" "unity_proxy_lambda_invocation" {
-  count         = contains(data.aws_lambda_functions.lambda_check_all.function_names, "unity-${var.venue}-httpdproxymanagement") ? 1 : 0
-  function_name = "unity-${var.venue}-httpdproxymanagement"
+  count         = contains(data.aws_lambda_functions.lambda_check_all.function_names, "${var.project}-${var.venue}-httpdproxymanagement") ? 1 : 0
+  function_name = "${var.project}-${var.venue}-httpdproxymanagement"
   input         = "{}"
   triggers = {
     redeployment = sha1(jsonencode([

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -635,7 +635,7 @@ resource "aws_ssm_parameter" "unity_proxy_airflow_ui" {
       Redirect "/${var.project}/${var.venue}/sps/home"
     </Location>
     <LocationMatch "^/${var.project}/${var.venue}/sps/(.*)$">
-      ProxyPassMatch "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/$1"
+      ProxyPassMatch "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/$1" retry=5 disablereuse=On
       ProxyPreserveHost On
       FallbackResource /management/index.html
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -638,6 +638,8 @@ resource "aws_ssm_parameter" "unity_proxy_airflow_ui" {
       ProxyPassMatch "http://${data.kubernetes_ingress_v1.airflow_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5000/$1"
       ProxyPreserveHost On
       FallbackResource /management/index.html
+      RequestHeader setifempty "X-Forwarded-Proto" "http"
+      RequestHeader setifempty "X-Forwarded-Port" expr=%%{SERVER_PORT}
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
       Substitute "s|\"/([^\"]*)|\"/${var.project}/${var.venue}/sps/$1|q"
     </LocationMatch>

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -390,6 +390,8 @@ resource "aws_ssm_parameter" "unity_proxy_ogc_api" {
       ProxyPassMatch "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5001/$1"
       ProxyPreserveHost On
       FallbackResource /management/index.html
+      RequestHeader setifempty "X-Forwarded-Proto" "http"
+      RequestHeader setifempty "X-Forwarded-Port" expr=%%{SERVER_PORT}
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
       Substitute "s|\"/([^\"]*)|\"/${var.project}/${var.venue}/ogc/$1|q"
     </LocationMatch>

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -387,7 +387,7 @@ resource "aws_ssm_parameter" "unity_proxy_ogc_api" {
       ProxyPassReverse "/"
     </Location>
     <LocationMatch "^/${var.project}/${var.venue}/ogc/(.*)$">
-      ProxyPassMatch "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5001/$1"
+      ProxyPassMatch "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5001/$1" retry=5 disablereuse=On
       ProxyPreserveHost On
       FallbackResource /management/index.html
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -390,8 +390,6 @@ resource "aws_ssm_parameter" "unity_proxy_ogc_api" {
       ProxyPassMatch "http://${data.kubernetes_ingress_v1.ogc_processes_api_ingress_internal.status[0].load_balancer[0].ingress[0].hostname}:5001/$1"
       ProxyPreserveHost On
       FallbackResource /management/index.html
-      RequestHeader setifempty "X-Forwarded-Proto" "http"
-      RequestHeader setifempty "X-Forwarded-Port" expr=%%{SERVER_PORT}
       AddOutputFilterByType INFLATE;SUBSTITUTE;DEFLATE text/html
       Substitute "s|\"/([^\"]*)|\"/${var.project}/${var.venue}/ogc/$1|q"
     </LocationMatch>

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -405,8 +405,8 @@ EOT
 data "aws_lambda_functions" "lambda_check_all" {}
 
 resource "aws_lambda_invocation" "unity_proxy_lambda_invocation" {
-  count         = contains(data.aws_lambda_functions.lambda_check_all.function_names, "unity-${var.venue}-httpdproxymanagement") ? 1 : 0
-  function_name = "unity-${var.venue}-httpdproxymanagement"
+  count         = contains(data.aws_lambda_functions.lambda_check_all.function_names, "${var.project}-${var.venue}-httpdproxymanagement") ? 1 : 0
+  function_name = "${var.project}-${var.venue}-httpdproxymanagement"
   input         = "{}"
   triggers = {
     redeployment = sha1(jsonencode([


### PR DESCRIPTION
## Purpose

- Fix the airflow page redirects by enabling the [proxyfix airflow parameter](https://airflow.apache.org/docs/apache-airflow/stable/howto/run-behind-proxy.html)

## Proposed Changes

- ADD enable_proxy_fix to airflow helm chart YAML

## Issues

- unity-sds/unity-cs#429

## Testing

- Currently deployed in `btl-dd2`/`dev`, accessible at:
  - http://btl-dd2-dev-httpd-alb-1592953208.us-west-2.elb.amazonaws.com:8080/btl-dd2/dev/sps/
  - https://www.dev.mdps.mcp.nasa.gov:4443/btl-dd2/dev/sps/