### PR TITLE
Adding S3 bucket policies to lock down unsecure access

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,4 +80,4 @@ repos:
       - id: terraform_docs
         args:
           - --hook-config=--add-to-existing-file=true
-          - --hook-config=--create-file-if-not-exist=true`
+          - --hook-config=--create-file-if-not-exist=true

--- a/terraform-unity/modules/terraform-unity-sps-airflow/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/README.md
@@ -40,6 +40,7 @@ No modules.
 | [aws_iam_role_policy_attachment.airflow_worker_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_invocation.unity_proxy_lambda_invocation](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/lambda_invocation) | resource |
 | [aws_s3_bucket.airflow_logs](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.airflow_logs_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_bucket_policy) | resource |
 | [aws_security_group.airflow_efs](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/security_group) | resource |
 | [aws_security_group.airflow_ingress_sg](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/security_group) | resource |
 | [aws_security_group.airflow_ingress_sg_internal](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/security_group) | resource |

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -124,6 +124,33 @@ resource "aws_s3_bucket" "airflow_logs" {
   })
 }
 
+resource "aws_s3_bucket_policy" "airflow_logs_s3_policy" {
+  bucket = aws_s3_bucket.airflow_logs.id
+  policy = jsonencode(
+    {
+      "Id" : "ExamplePolicy",
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "AllowSSLRequestsOnly",
+          "Action" : "s3:*",
+          "Effect" : "Deny",
+          "Resource" : [
+            format("%s%s", "arn:aws:s3:::", format(local.resource_name_prefix, "airflowlogs")),
+            format("%s%s/%s", "arn:aws:s3:::", format(local.resource_name_prefix, "airflowlogs"), "*")
+          ],
+          "Condition" : {
+            "Bool" : {
+              "aws:SecureTransport" : "false"
+            }
+          },
+          "Principal" : "*"
+        }
+      ]
+    }
+  )
+}
+
 resource "aws_iam_policy" "airflow_worker_policy" {
   name        = format(local.resource_name_prefix, "AirflowWorkerPolicy")
   description = "Policy for Airflow Workers to access AWS services"

--- a/terraform-unity/modules/terraform-unity-sps-initiators/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-initiators/README.md
@@ -26,6 +26,7 @@
 | [aws_s3_bucket.code](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.config](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.inbound_staging_location](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.ssl_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_object.isl_stacam_rawdp_folder](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_object) | resource |
 | [aws_s3_object.router_config](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/resources/s3_object) | resource |
 | [aws_ssm_parameter.airflow_api_url](https://registry.terraform.io/providers/hashicorp/aws/5.67.0/docs/data-sources/ssm_parameter) | data source |

--- a/terraform-unity/modules/terraform-unity-sps-initiators/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-initiators/main.tf
@@ -29,12 +29,12 @@ resource "aws_s3_bucket" "config" {
 }
 
 resource "aws_s3_bucket_policy" "ssl_s3_policy" {
-  for_each = tomap({
-    isl    = aws_s3_bucket.inbound_staging_location.id,
-    code   = aws_s3_bucket.code.id,
-    config = aws_s3_bucket.config.id
-  })
-  bucket = format(local.resource_name_prefix, each.value)
+  for_each = toset([
+    "isl",
+    "code",
+    "config"
+  ])
+  bucket = format(local.resource_name_prefix, each.key)
   policy = jsonencode(
     {
       "Id" : "ExamplePolicy",


### PR DESCRIPTION
## Purpose

- Adds s3 bucket policy to block unsecure access on the various S3 buckets created by the unity-sps terraform

## Proposed Changes

- ADD `aws_s3_bucket_policy` entries for the 4 buckets that are created (one in `terraform-unity-sps-airflow`, three in `terraform-unity-sps-initiators`)

## Issues

- unity-sds/unity-sps#231

## Testing

- Tested in personal deployment; deployed without issues...
- Unsure of how to test the initiators buckets.