### PR TITLE
#242 - Remove Airflow authentication

### DIFF
--- a/airflow/config/webserver_config.py
+++ b/airflow/config/webserver_config.py
@@ -1,0 +1,2 @@
+# Disable airflow authentication, https://airflow.apache.org/docs/apache-airflow-providers-fab/stable/auth-manager/webserver-authentication.html
+AUTH_ROLE_PUBLIC = 'Admin'

--- a/airflow/helm/values.tmpl.yaml
+++ b/airflow/helm/values.tmpl.yaml
@@ -130,6 +130,9 @@ webserverSecretKeySecretName: ${webserver_secret_name}
 webserver:
   replicas: 3
 
+  webserverConfig: |-
+    ${webserver_config}
+
   startupProbe:
     timeoutSeconds: 20
     failureThreshold: 60 # Number of tries before giving up (10 minutes with periodSeconds of 10)

--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -412,6 +412,7 @@ resource "helm_release" "airflow" {
       unity_cluster_name       = data.aws_eks_cluster.cluster.name
       karpenter_node_pools     = join(",", var.karpenter_node_pools)
       cwl_dag_ecr_uri          = "${data.aws_caller_identity.current.account_id}.dkr.ecr.us-west-2.amazonaws.com"
+      webserver_config         = indent(4, file("${path.module}/../../../airflow/config/webserver_config.py"))
     })
   ]
   set_sensitive {


### PR DESCRIPTION
## Purpose

Remove Airflow authentication so the user only needs to authenticate with Cognito when navigating to the top-level proxy URL.

## Proposed Changes

- [REMOVED] Removed Airflow authentication

## Issues

- #242 - Experiment with removing the Airflow authentication altogether

## Testing

- Deployed modifications on existing Airflow installation and confirmed no authentication was required. No login screen was presented when navigating to the UI and landed on the Airflow dashboard.
- Destroyed Airflow deployment and re-deployed. Confirmed that no authentication is required for a new deployment.
- The option to log in is still present in the upper, right of the UI and if the user clicks on the "Log In" button they can log in with the `airflow_webserver_username` and `airflow_webserver_password` defined in the deployment's .tfvars file.

https://k8s-sps-airflowi-5934bc27ad-1282880704.us-west-2.elb.amazonaws.com:5000/home
![Screenshot 2024-12-03 at 16 14 49](https://github.com/user-attachments/assets/de6c6f49-48fc-4c26-8bee-9c171aec2155)