### PR TITLE
Adding empty "" for deployment name for EKS and Karpenter

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-eks/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-eks/README.md
@@ -18,7 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module | 59-sps-eks-marketplace-adjustments |
+| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module | unity-sps-2.4.0 |
 
 ## Resources
 
@@ -31,7 +31,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the deployment. | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the deployment. | `string` | `""` | no |
 | <a name="input_installprefix"></a> [installprefix](#input\_installprefix) | The install prefix for the service area (unused) | `string` | `""` | no |
 | <a name="input_nodegroups"></a> [nodegroups](#input\_nodegroups) | A map of node group configurations | <pre>map(object({<br>    create_iam_role            = optional(bool)<br>    iam_role_arn               = optional(string)<br>    ami_id                     = optional(string)<br>    min_size                   = optional(number)<br>    max_size                   = optional(number)<br>    desired_size               = optional(number)<br>    instance_types             = optional(list(string))<br>    capacity_type              = optional(string)<br>    enable_bootstrap_user_data = optional(bool)<br>    metadata_options           = optional(map(any))<br>    block_device_mappings = optional(map(object({<br>      device_name = string<br>      ebs = object({<br>        volume_size           = number<br>        volume_type           = string<br>        encrypted             = bool<br>        delete_on_termination = bool<br>      })<br>    })))<br>  }))</pre> | <pre>{<br>  "defaultGroup": {<br>    "block_device_mappings": {<br>      "xvda": {<br>        "device_name": "/dev/xvda",<br>        "ebs": {<br>          "delete_on_termination": true,<br>          "encrypted": true,<br>          "volume_size": 100,<br>          "volume_type": "gp2"<br>        }<br>      }<br>    },<br>    "desired_size": 1,<br>    "instance_types": [<br>      "t3.xlarge"<br>    ],<br>    "max_size": 1,<br>    "metadata_options": {<br>      "http_endpoint": "enabled",<br>      "http_put_response_hop_limit": 3<br>    },<br>    "min_size": 1<br>  }<br>}</pre> | no |
 | <a name="input_project"></a> [project](#input\_project) | The project or mission deploying Unity SPS | `string` | `"unity"` | no |

--- a/terraform-unity/modules/terraform-unity-sps-eks/variables.tf
+++ b/terraform-unity/modules/terraform-unity-sps-eks/variables.tf
@@ -25,6 +25,7 @@ variable "release" {
 variable "deployment_name" {
   description = "The name of the deployment."
   type        = string
+  default     = ""
 }
 
 # tflint-ignore: terraform_unused_declarations

--- a/terraform-unity/modules/terraform-unity-sps-karpenter/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-karpenter/README.md
@@ -35,7 +35,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the deployment. | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the deployment. | `string` | `""` | no |
 | <a name="input_helm_charts"></a> [helm\_charts](#input\_helm\_charts) | Helm charts for the associated services. | <pre>map(object({<br>    repository = string<br>    chart      = string<br>    version    = string<br>  }))</pre> | <pre>{<br>  "karpenter": {<br>    "chart": "karpenter",<br>    "repository": "oci://public.ecr.aws/karpenter",<br>    "version": "1.0.2"<br>  }<br>}</pre> | no |
 | <a name="input_installprefix"></a> [installprefix](#input\_installprefix) | The install prefix for the service area (unused) | `string` | `""` | no |
 | <a name="input_project"></a> [project](#input\_project) | The project or mission deploying Unity SPS | `string` | `"unity"` | no |

--- a/terraform-unity/modules/terraform-unity-sps-karpenter/variables.tf
+++ b/terraform-unity/modules/terraform-unity-sps-karpenter/variables.tf
@@ -25,6 +25,7 @@ variable "release" {
 variable "deployment_name" {
   description = "The name of the deployment."
   type        = string
+  default     = ""
 }
 
 # tflint-ignore: terraform_unused_declarations


### PR DESCRIPTION
## Purpose

- Adding a sensible default for the "deployment_name" variable for EKS and Karpenter

## Proposed Changes

- [CHANGE] The "deployment_name" variable defaults to ""

## Issues

- No associated issue, this is a quick fix

## Testing

- Successfully deployed EKS and Karpenter without having to specify the value of "deployment_name"
