### PR TITLE
[New Feature] Replace selection of CPU, memory with selection of specific EC2 type

### DIFF
--- a/ogc-application-packages/cwl_dag.json
+++ b/ogc-application-packages/cwl_dag.json
@@ -27,15 +27,6 @@
         },
         "title": "CWL Workflow URL"
       },
-      "request_cpu": {
-        "description": "The number of CPU cores requested for the job",
-        "maxOccurs": 1,
-        "minOccurs": 1,
-        "schema": {
-          "type": "string"
-        },
-        "title": "Requested CPU"
-      },
       "request_instance_type": {
         "description": "The specific EC2 instance type requested for the job",
         "maxOccurs": 1,
@@ -44,16 +35,6 @@
           "type": "string"
         },
         "title": "Requested EC2 Type"
-      },
-      "request_memory": {
-        "default": "8Gi",
-        "description": "The amount of memory requested for the job",
-        "maxOccurs": 1,
-        "minOccurs": 1,
-        "schema": {
-          "type": "string"
-        },
-        "title": "Requested Memory"
       },
       "request_storage": {
         "description": "The amount of storage requested for the job",

--- a/unity-test/system/integration/step_defs/test_cwl_workflows_with_airflow_api.py
+++ b/unity-test/system/integration/step_defs/test_cwl_workflows_with_airflow_api.py
@@ -81,8 +81,6 @@ def trigger_dag(airflow_api_url, airflow_api_auth, venue, test_case):
         # DAG parameters are venue dependent
         cwl_workflow = DAG_PARAMETERS[test_case]["cwl_workflow"]
         cwl_args = DAG_PARAMETERS[test_case]["cwl_args"][venue]
-        request_memory = DAG_PARAMETERS[test_case]["request_memory"]
-        request_cpu = DAG_PARAMETERS[test_case]["request_cpu"]
         request_storage = DAG_PARAMETERS[test_case]["request_storage"]
         request_instance_type = DAG_PARAMETERS[test_case]["request_instance_type"]
         use_ecr = DAG_PARAMETERS[test_case]["use_ecr"]
@@ -93,8 +91,6 @@ def trigger_dag(airflow_api_url, airflow_api_auth, venue, test_case):
                 "conf": {
                     "cwl_workflow": f"{cwl_workflow}",
                     "cwl_args": f"{cwl_args}",
-                    "request_memory": f"{request_memory}",
-                    "request_cpu": f"{request_cpu}",
                     "request_storage": f"{request_storage}",
                     "request_instance_type": f"{request_instance_type}",
                     "use_ecr": use_ecr,

--- a/unity-test/system/integration/step_defs/test_cwl_workflows_with_airflow_api.py
+++ b/unity-test/system/integration/step_defs/test_cwl_workflows_with_airflow_api.py
@@ -28,8 +28,6 @@ DAG_PARAMETERS = {
             # "test": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main"
             # "/test/emit-ghg-test.json",
         },
-        "request_memory": "32Gi",
-        "request_cpu": "8",
         "request_storage": "100Gi",
         # r7i.2xlarge: 8 CPUs, 64 GB memory
         "request_instance_type": "r7i.2xlarge",
@@ -42,8 +40,6 @@ DAG_PARAMETERS = {
             "dev": "https://raw.githubusercontent.com/unity-sds/"
             "sbg-workflows/refs/heads/main/L1-to-L2-e2e.dev.yml",
         },
-        "request_memory": "64Gi",
-        "request_cpu": "32",
         "request_storage": "100Gi",
         # c6i.8xlarge: 32 CPUs, 64 GB memory
         "request_instance_type": "c6i.8xlarge",
@@ -58,8 +54,6 @@ DAG_PARAMETERS = {
             "test": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess"
             "/sbg-preprocess-workflow.test.yml",
         },
-        "request_memory": "16Gi",
-        "request_cpu": "4",
         "request_storage": "10Gi",
         # c6i.xlarge: 4vCPUs, 8 GB memory
         # r7i.xlarge: 4 CPUs 32 GB memory

--- a/unity-test/system/integration/step_defs/test_cwl_workflows_with_ogc_api.py
+++ b/unity-test/system/integration/step_defs/test_cwl_workflows_with_ogc_api.py
@@ -26,8 +26,6 @@ DATA = {
             "cwl_args": {
                 "dev": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main/test/emit-ghg-dev.json"
             },
-            "request_memory": "32Gi",
-            "request_cpu": "8",
             "request_storage": "100Gi",
             # r7i.2xlarge: 8 CPUs, 64 GB memory
             "request_instance_type": "r7i.2xlarge",
@@ -45,8 +43,6 @@ DATA = {
                 "test": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess"
                 "/sbg-preprocess-workflow.test.yml",
             },
-            "request_memory": "16Gi",
-            "request_cpu": "4",
             "request_storage": "10Gi",
             # c6i.xlarge: 4vCPUs, 8 GB memory
             # r7i.xlarge: 4 CPUs 32 GB memory
@@ -63,8 +59,6 @@ DATA = {
                 "dev": "https://raw.githubusercontent.com/unity-sds/"
                 "sbg-workflows/refs/heads/main/L1-to-L2-e2e.dev.yml",
             },
-            "request_memory": "64Gi",
-            "request_cpu": "32",
             "request_storage": "100Gi",
             # c6i.8xlarge: 32 CPUs, 64 GB memory
             "request_instance_type": "c6i.8xlarge",


### PR DESCRIPTION
## Purpose

- This PR will allow users to select a specific EC2 type when executing a CWL workflow, while removing the ability to generically select memory and CPU. The latter can lead to workflow failures if the user is not careful about their selection.

## Proposed Changes

- [ADD] DAG parameter to select an EC2 type, replacing the parameters to select CPU and memory
- [CHANGE] All integration tests to request an instance type and not a certain amount of memory and CPU

## Issues

- https://github.com/unity-sds/unity-sps/issues/252

## Testing

- Integration tests succeeded on personal "luca-1" SPS instance
