### PR TITLE
Bumping pinned eks_module reference to new (fixed) source tag

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-eks/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-eks/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "unity-eks" {
-  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.4.0"
+  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.4.1"
   deployment_name = local.cluster_name
   project         = var.project
   venue           = var.venue


### PR DESCRIPTION
## Purpose

- Bumping the terraform-unity-eks_module (from the unity-cs-infra repo) pinned version up to their fixed version, which has pruned out the references to the ami_1_28 ssm params.

## Proposed Changes

- CHANGE pinned ref in module source

## Issues

- No relevant issues, chore.

## Testing

- To be tested in personal deployment, not yet ready for merge.