### PR TITLE
Bumping eks_module source tag

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-eks/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-eks/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "unity-eks" {
-  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.4.1"
+  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.4.1-hotfix1"
   deployment_name = local.cluster_name
   project         = var.project
   venue           = var.venue


### PR DESCRIPTION
## Purpose

- Updating the tag referenced in the terraform-unity-sps-eks module sourcing

## Proposed Changes

- CHANGE tag from `unity-sps-2.4.1` to `unity-sps-2.4.1-hotfix1`

## Issues

- No relevant issue

## Testing

- Tested in local deployment