### PR TITLE
Log instance ID on pod before executing CWL

### DIFF
--- a/airflow/docker/cwl/Dockerfile
+++ b/airflow/docker/cwl/Dockerfile
@@ -4,7 +4,7 @@ FROM docker:25.0.3-dind
 
 # install Python
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
-RUN apk add gcc musl-dev linux-headers python3-dev jq
+RUN apk add gcc musl-dev linux-headers python3-dev jq curl
 RUN apk add --no-cache python3 py3-pip
 RUN apk add vim
 

--- a/airflow/docker/cwl/docker_cwl_entrypoint.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint.sh
@@ -11,13 +11,6 @@
 #        (example: <aws_account_id>.dkr.ecr.<region>.amazonaws.com) [optional]
 # -o: path to an output JSON file that needs to be shared as Airflow "xcom" data [optional]
 
-# Set equal to the path of the EFS Persistent Volume mounted by the Airflow KubernetesPodOperator
-# that executes this script
-# WORKING_DIR="/scratch"
-
-# Set to a local path on the Pod EBS volume
-WORKING_DIR="/data"
-
 while getopts w:j:e:o:l: flag
 do
   case "${flag}" in
@@ -35,6 +28,18 @@ if [ "$log_level" -eq 10 ]; then
 else
   set -e
 fi
+
+# echo instance ID to logs
+TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+instance_id=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+echo INSTANCE ID: $instance_id
+
+# Set equal to the path of the EFS Persistent Volume mounted by the Airflow KubernetesPodOperator
+# that executes this script
+# WORKING_DIR="/scratch"
+
+# Set to a local path on the Pod EBS volume
+WORKING_DIR="/data"
 
 # create working directory if it doesn't exist
 mkdir -p "$WORKING_DIR"

--- a/airflow/docker/cwl/docker_cwl_entrypoint_modular.sh
+++ b/airflow/docker/cwl/docker_cwl_entrypoint_modular.sh
@@ -15,10 +15,6 @@
 #        (example: <aws_account_id>.dkr.ecr.<region>.amazonaws.com) [optional]
 # -f: path to an output JSON file that needs to be shared as Airflow "xcom" data [optional]
 
-# Can be the same as the path of the Persistent Volume mounted by the Airflow KubernetesPodOperator
-# that executes this script to execute on EFS.
-WORKING_DIR="/data"    # Set to EBS directory
-
 get_job_args() {
   local job_args=$1
   workflow=$2
@@ -58,6 +54,15 @@ if [ "$log_level" -eq 10 ]; then
 else
   set -e
 fi
+
+# Echo instance ID to logs
+TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+instance_id=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+echo INSTANCE ID: $instance_id
+
+# Can be the same as the path of the Persistent Volume mounted by the Airflow KubernetesPodOperator
+# that executes this script to execute on EFS.
+WORKING_DIR="/data"    # Set to EBS directory
 
 # Create working directory if it doesn't exist
 mkdir -p "$WORKING_DIR"


### PR DESCRIPTION
## Purpose

Log EC2 instance Id so that users can associate Airflow jobs with underlying physical hardware.

## Proposed Changes

- [ADD] Retrieve instance id from EC2 instance metadata and echo to screen to both CWL DAG and modular CWL DAG

## Issues

- #357 - [New Feature]: Log the EC2 Instance Id

## Testing

Ran in `unity-venue-dev` on `unity-nikki-2` deployment.

- Confirmed instance ID is echoed:

```bash
[2025-03-19, 14:57:37 UTC] {pod_manager.py:471} INFO - [base] INSTANCE ID: i-08d4c8bde4561b80f
```

- Confirmed that is the node that the pod launched on; tested for both CWL DAG and modular DAG
