### PR TITLE
Update EKS version to 1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [UNRELEASED] - 
+
+- Updated EKS Module to use updated tag and cluster_version 1.31
+
+
+
 # [Unity Release 25.1] - 2025-04-08
 
 - SPS Version 2.6.0 (new)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [UNRELEASED] - 
+# [UNRELEASED] -
 
 - Updated EKS Module to use updated tag and cluster_version 1.31
 

--- a/terraform-unity/modules/terraform-unity-sps-eks/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-eks/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "unity-eks" {
-  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.4.1-hotfix1"
+  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=7f64fe1"
   deployment_name = local.cluster_name
   project         = var.project
   venue           = var.venue
@@ -24,7 +24,7 @@ module "unity-eks" {
     Component = "eks"
     Stack     = "eks"
   })
-  cluster_version = "1.29"
+  cluster_version = "1.31"
 }
 
 resource "null_resource" "eks_post_deployment_actions" {


### PR DESCRIPTION
## Purpose

- Updates to support EKS 1.31
- 
## Proposed Changes

- [CHANGE] Updated cluster version to `1.31` and updated git reference to new commit.

## Issues

- Closes #243 

## Testing

- Deployed version of EKS, karpenter and Airflow to unity-venue-dev. Ran sample hello world workflow as proof of concept.
- Note: I accessed the airflow UI environment by tunneling with kubectl, not through the proxies. 
