### PR TITLE
Updating versions to upgrade to EKS 1.31

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-eks/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-eks/README.md
@@ -20,7 +20,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module | unity-sps-2.4.1-hotfix1 |
+| <a name="module_unity-eks"></a> [unity-eks](#module\_unity-eks) | git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module | unity-sps-2.5.0 |
 
 ## Resources
 

--- a/terraform-unity/modules/terraform-unity-sps-eks/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-eks/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "unity-eks" {
-  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.4.1-hotfix1"
+  source          = "git::https://github.com/unity-sds/unity-cs-infra.git//terraform-unity-eks_module?ref=unity-sps-2.5.0"
   deployment_name = local.cluster_name
   project         = var.project
   venue           = var.venue
@@ -24,7 +24,7 @@ module "unity-eks" {
     Component = "eks"
     Stack     = "eks"
   })
-  cluster_version = "1.29"
+  cluster_version = "1.31"
 }
 
 resource "null_resource" "eks_post_deployment_actions" {

--- a/terraform-unity/modules/terraform-unity-sps-karpenter/README.md
+++ b/terraform-unity/modules/terraform-unity-sps-karpenter/README.md
@@ -36,7 +36,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the deployment. | `string` | `""` | no |
-| <a name="input_helm_charts"></a> [helm\_charts](#input\_helm\_charts) | Helm charts for the associated services. | <pre>map(object({<br>    repository = string<br>    chart      = string<br>    version    = string<br>  }))</pre> | <pre>{<br>  "karpenter": {<br>    "chart": "karpenter",<br>    "repository": "oci://public.ecr.aws/karpenter",<br>    "version": "1.0.2"<br>  }<br>}</pre> | no |
+| <a name="input_helm_charts"></a> [helm\_charts](#input\_helm\_charts) | Helm charts for the associated services. | <pre>map(object({<br>    repository = string<br>    chart      = string<br>    version    = string<br>  }))</pre> | <pre>{<br>  "karpenter": {<br>    "chart": "karpenter",<br>    "repository": "oci://public.ecr.aws/karpenter",<br>    "version": "1.3.3"<br>  }<br>}</pre> | no |
 | <a name="input_installprefix"></a> [installprefix](#input\_installprefix) | The install prefix for the service area (unused) | `string` | `""` | no |
 | <a name="input_project"></a> [project](#input\_project) | The project or mission deploying Unity SPS | `string` | `"unity"` | no |
 | <a name="input_release"></a> [release](#input\_release) | The software release version. | `string` | `"25.1"` | no |

--- a/terraform-unity/modules/terraform-unity-sps-karpenter/variables.tf
+++ b/terraform-unity/modules/terraform-unity-sps-karpenter/variables.tf
@@ -53,7 +53,7 @@ variable "helm_charts" {
     karpenter = {
       repository = "oci://public.ecr.aws/karpenter"
       chart      = "karpenter"
-      version    = "1.0.2"
+      version    = "1.3.3"
     }
   }
 }


### PR DESCRIPTION
## Purpose

- Update SPS to be deployed on EKS version 1.31

## Proposed Changes

- [CHANGE] Underlying EKS version to be 1.31
- [CHANGE] Upgrade Karpenter Helm chart to be 1.3.3

## Issues

- [Upgrade SPS to latest EKS version 1.30](https://github.com/unity-sds/unity-sps/issues/243)

## Testing

- Successfully deployed SPS on EKS 1.31 cluster
- Successfully executed the "echo" DAG and the EMIT CWL DAG
