### PR TITLE
#335 [New Feature]: Usability improvements to CWL DAGs

### DIFF
--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -52,7 +52,7 @@ CONTAINER_RESOURCES = k8s.V1ResourceRequirements(
     }
 )
 
-LOG_LEVEL_TYPE = {10: "DEBUG", 20: "INFO"}
+LOG_LEVEL_TYPE = {"DEBUG": 10, "INFO": 20}
 
 # Default DAG configuration
 dag_default_args = {
@@ -84,9 +84,8 @@ dag = DAG(
         ),
         "log_level": Param(
             DEFAULT_LOG_LEVEL,
-            type="integer",
+            type="string",
             enum=list(LOG_LEVEL_TYPE.keys()),
-            values_display={key: f"{key} ({value})" for key, value in LOG_LEVEL_TYPE.items()},
             title="Processing log levels",
             description=("Log level for DAG processing"),
         ),
@@ -143,7 +142,9 @@ def setup(ti=None, **context):
     logging.info("ECR login: %s", ecr_login)
 
     # select log level based on debug
-    logging.info(f"Selecting log level: {context['params']['log_level']}.")
+    log_level = context['params']['log_level']
+    ti.xcom_push(key="log_level", value=LOG_LEVEL_TYPE[log_level])
+    logging.info(f"Selecting log level: {LOG_LEVEL_TYPE[log_level]}.")
 
 
 setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag, weight_rule="upstream")
@@ -165,7 +166,7 @@ cwl_task = KubernetesPodOperator(
         "-j",
         "{{ params.cwl_args }}",
         "-l",
-        "{{ params.log_level }}",
+        "{{ ti.xcom_pull(task_ids='Setup', key='log_level') }}",
         "-e",
         "{{ ti.xcom_pull(task_ids='Setup', key='ecr_login') }}",
     ],

--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -100,7 +100,6 @@ dag = DAG(
         "request_storage": Param(
             "10Gi", type="string", enum=["10Gi", "50Gi", "100Gi", "150Gi", "200Gi", "250Gi"]
         ),
-        "use_ecr": Param(False, type="boolean", title="Log into AWS Elastic Container Registry (ECR)"),
     },
 )
 
@@ -138,12 +137,10 @@ def setup(ti=None, **context):
     logging.info(f"Selecting node pool={node_pool}")
     ti.xcom_push(key="node_pool", value=node_pool)
 
-    # select "use_ecr" argument and determine if ECR login is required
-    logging.info("Use ECR: %s", context["params"]["use_ecr"])
-    if context["params"]["use_ecr"]:
-        ecr_login = os.environ["AIRFLOW_VAR_ECR_URI"]
-        ti.xcom_push(key="ecr_login", value=ecr_login)
-        logging.info("ECR login: %s", ecr_login)
+    # select ECR login URL
+    ecr_login = os.environ["AIRFLOW_VAR_ECR_URI"]
+    ti.xcom_push(key="ecr_login", value=ecr_login)
+    logging.info("ECR login: %s", ecr_login)
 
     # select log level based on debug
     logging.info(f"Selecting log level: {context['params']['log_level']}.")

--- a/airflow/dags/cwl_dag.py
+++ b/airflow/dags/cwl_dag.py
@@ -142,7 +142,7 @@ def setup(ti=None, **context):
     logging.info("ECR login: %s", ecr_login)
 
     # select log level based on debug
-    log_level = context['params']['log_level']
+    log_level = context["params"]["log_level"]
     ti.xcom_push(key="log_level", value=LOG_LEVEL_TYPE[log_level])
     logging.info(f"Selecting log level: {LOG_LEVEL_TYPE[log_level]}.")
 

--- a/airflow/dags/cwl_dag_modular.py
+++ b/airflow/dags/cwl_dag_modular.py
@@ -120,7 +120,6 @@ dag = DAG(
         "request_storage": Param(
             "10Gi", type="string", enum=["10Gi", "50Gi", "100Gi", "150Gi", "200Gi", "250Gi"]
         ),
-        "use_ecr": Param(False, type="boolean", title="Log into AWS Elastic Container Registry (ECR)"),
     },
 )
 
@@ -156,15 +155,13 @@ def select_node_pool(ti, request_storage, request_instance_type):
     logging.info(f"Selecting node pool={node_pool}")
 
 
-def select_ecr(ti, use_ecr):
+def select_ecr(ti):
     """
-    Determine if ECR login is required.
+    Determine ECR login.
     """
-    logging.info("Use ECR: %s", use_ecr)
-    if use_ecr:
-        ecr_login = os.environ["AIRFLOW_VAR_ECR_URI"]
-        ti.xcom_push(key="ecr_login", value=ecr_login)
-        logging.info("ECR login: %s", ecr_login)
+    ecr_login = os.environ["AIRFLOW_VAR_ECR_URI"]
+    ti.xcom_push(key="ecr_login", value=ecr_login)
+    logging.info("ECR login: %s", ecr_login)
 
 
 def select_stage_out(ti):
@@ -196,8 +193,8 @@ def setup(ti=None, **context):
     # select the node pool based on what resources were requested
     select_node_pool(ti, context["params"]["request_storage"], context["params"]["request_instance_type"])
 
-    # select "use_ecr" argument and determine if ECR login is required
-    select_ecr(ti, context["params"]["use_ecr"])
+    # determine ECR login
+    select_ecr(ti)
 
     # retrieve stage out aws api key and account id
     select_stage_out(ti)

--- a/airflow/dags/cwl_dag_modular.py
+++ b/airflow/dags/cwl_dag_modular.py
@@ -206,7 +206,7 @@ def setup(ti=None, **context):
     select_stage_out(ti)
 
     # select log level based on debug
-    select_log_level(ti, context['params']['log_level'])
+    select_log_level(ti, context["params"]["log_level"])
 
 
 setup_task = PythonOperator(task_id="Setup", python_callable=setup, dag=dag, weight_rule="upstream")

--- a/airflow/plugins/unity_sps_utils.py
+++ b/airflow/plugins/unity_sps_utils.py
@@ -21,7 +21,7 @@ NODE_POOL_HIGH_WORKLOAD = "airflow-kubernetes-pod-operator-high-workload"
 DS_S3_BUCKET_PARAM = f"/unity/unity/{os.environ['AIRFLOW_VAR_UNITY_VENUE']}/ds/datastore-bucket"
 
 DEFAULT_LOG_LEVEL = "INFO"
-LOG_LEVEL_TYPE = {"DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40,"CRITICAL": 50}
+LOG_LEVEL_TYPE = {"DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40, "CRITICAL": 50}
 
 EC2_TYPES = {
     # "t3.nano": {

--- a/airflow/plugins/unity_sps_utils.py
+++ b/airflow/plugins/unity_sps_utils.py
@@ -20,8 +20,8 @@ NODE_POOL_HIGH_WORKLOAD = "airflow-kubernetes-pod-operator-high-workload"
 
 DS_S3_BUCKET_PARAM = f"/unity/unity/{os.environ['AIRFLOW_VAR_UNITY_VENUE']}/ds/datastore-bucket"
 
-DEFAULT_LOG_LEVEL = 20
-LOG_LEVEL_TYPE = {10: "DEBUG", 20: "INFO", 30: "WARNING", 40: "ERROR", 50: "CRITICAL"}
+DEFAULT_LOG_LEVEL = "INFO"
+LOG_LEVEL_TYPE = {"DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40,"CRITICAL": 50}
 
 EC2_TYPES = {
     # "t3.nano": {

--- a/terraform-unity/main.tf
+++ b/terraform-unity/main.tf
@@ -77,14 +77,14 @@ module "unity-sps-ogc-processes-api" {
   karpenter_node_pools       = module.unity-sps-karpenter-node-config.karpenter_node_pools
 }
 
-module "unity-sps-initiators" {
-  source                          = "./modules/terraform-unity-sps-initiators"
-  project                         = var.project
-  venue                           = var.venue
-  service_area                    = var.service_area
-  release                         = var.release
-  airflow_api_url_ssm_param       = module.unity-sps-airflow.airflow_urls["rest_api"].ssm_param_id
-  airflow_webserver_username      = var.airflow_webserver_username
-  airflow_webserver_password      = var.airflow_webserver_password
-  ogc_processes_api_url_ssm_param = module.unity-sps-ogc-processes-api.ogc_processes_urls["rest_api"].ssm_param_id
-}
+# module "unity-sps-initiators" {
+#   source                          = "./modules/terraform-unity-sps-initiators"
+#   project                         = var.project
+#   venue                           = var.venue
+#   service_area                    = var.service_area
+#   release                         = var.release
+#   airflow_api_url_ssm_param       = module.unity-sps-airflow.airflow_urls["rest_api"].ssm_param_id
+#   airflow_webserver_username      = var.airflow_webserver_username
+#   airflow_webserver_password      = var.airflow_webserver_password
+#   ogc_processes_api_url_ssm_param = module.unity-sps-ogc-processes-api.ogc_processes_urls["rest_api"].ssm_param_id
+# }


### PR DESCRIPTION
## Purpose

Small updates to CWL DAG and modular CWL DAG to improve usability.

## Proposed Changes

- [CHANGE] Log levels to remove numeric identifier from input parameter display
- [CHANGE] Remove option to use ECR from input parameter display and always log into ECR

## Issues

- #335 

## Testing

Ran in `unity-venue-dev` on `unity-nikki-1` deployment.

Confirmed log level display looks correct and log levels still function for entrypoint scripts:
![Screenshot 2025-04-14 at 11 03 42](https://github.com/user-attachments/assets/570522a5-45f3-4d6a-9d2c-f72656dbe978)

```bash
[2025-04-14, 14:55:40 UTC] {pod_manager.py:471} INFO - [base] 2025-04-14 14:55:40,843 [DEBUG] [mdps_ds_lib.stage_in_out.download_granules_abstract::104] attempting to decode raw_stac_json to JSON object
[2025-04-14, 14:55:40 UTC] {pod_manager.py:471} INFO - [base] 2025-04-14 14:55:40,843 [DEBUG] [mdps_ds_lib.stage_in_out.download_granules_abstract::109] raw_stac_json is not STAC_JSON: https://raw.githubusercontent.com/unity-sds/unity-tutorial-application/refs/heads/main/test/stage_in/stage_in_results.json. trying to see if file exists
[2025-04-14, 14:55:40 UTC] {pod_manager.py:471} INFO - [base] 2025-04-14 14:55:40,844 [DEBUG] [mdps_ds_lib.stage_in_out.download_granules_abstract::120] download raw stac json from public URL: https://raw.githubusercontent.com/unity-sds/unity-tutorial-application/refs/heads/main/test/stage_in/stage_in_results.json
[2025-04-14, 14:55:40 UTC] {pod_manager.py:471} INFO - [base] 2025-04-14 14:55:40,846 [DEBUG] [urllib3.connectionpool::1003] Starting new HTTPS connection (1): raw.githubusercontent.com:443
```

Confirmed `use_ecr` option is removed but DAGs still log into ECR:

```bash
[2025-04-14, 14:54:35 UTC] {pod_manager.py:471} INFO - [base] Login Succeeded
[2025-04-14, 14:54:35 UTC] {pod_manager.py:471} INFO - [base] Logged into: xxxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com
```
