### PR TITLE
Updating the CWL classic tests to use the latest Data Service Docker container

### DIFF
--- a/unity-test/system/integration/step_defs/test_cwl_workflows_with_airflow_api.py
+++ b/unity-test/system/integration/step_defs/test_cwl_workflows_with_airflow_api.py
@@ -34,51 +34,44 @@ DAG_PARAMETERS = {
             },
             "request_storage": "10Gi",
             "request_instance_type": "t3.medium",
-            "use_ecr": False,
         }
     },
     CWL_DAG_ID: {
         "EMIT": {
-            "cwl_workflow": "http://awslbdockstorestack-lb-1429770210.us-west-2.elb.amazonaws.com:9998/"
-            "api/ga4gh/trs/v2/tools/%23workflow%2Fdockstore.org%2FGodwinShen%2Femit-ghg/"
-            "versions/9/plain-CWL/descriptor/workflow.cwl",
+            # "cwl_workflow": "http://awslbdockstorestack-lb-1429770210.us-west-2.elb.amazonaws.com:9998/api/ga4gh/trs/v2/tools/%23workflow%2Fdockstore.org%2FGodwinShen%2Femit-ghg/versions/9/plain-CWL/descriptor/workflow.cwl",
+            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/emit/GodwinShen/workflow.cwl",
             "cwl_args": {
-                "dev": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main"
-                "/test/emit-ghg-dev.json",
-                # "test": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main"
-                # "/test/emit-ghg-test.json",
+                # "dev": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main/test/emit-ghg-dev.json",
+                "dev": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/emit/GodwinShen/emit-ghg-dev.json",
+                # "test": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main/test/emit-ghg-test.json",
             },
             "request_storage": "100Gi",
-            # r7i.2xlarge: 8 CPUs, 64 GB memory
             "request_instance_type": "r7i.2xlarge",
-            "use_ecr": False,
         },
         "SBG_E2E_SCALE": {
-            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/"
-            "sbg-workflows/refs/heads/main/L1-to-L2-e2e.cwl",
+            # "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/refs/heads/main/L1-to-L2-e2e.cwl",
+            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/l1-to-l2-e2e/L1-to-L2-e2e.cwl",
             "cwl_args": {
-                "dev": "https://raw.githubusercontent.com/unity-sds/"
-                "sbg-workflows/refs/heads/main/L1-to-L2-e2e.dev.yml",
+                # "dev": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/refs/heads/main/L1-to-L2-e2e.dev.yml",
+                "dev": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/l1-to-l2-e2e/L1-to-L2-e2e.dev.yml",
             },
             "request_storage": "100Gi",
             # c6i.8xlarge: 32 CPUs, 64 GB memory
             "request_instance_type": "c6i.8xlarge",
-            "use_ecr": False,
         },
         "SBG_PREPROCESS": {
-            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main"
-            "/preprocess/sbg-preprocess-workflow.cwl",
+            # "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl",
+            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/preprocess/sbg-preprocess-workflow.cwl",
             "cwl_args": {
-                "dev": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess"
-                "/sbg-preprocess-workflow.dev.yml",
-                "test": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess"
-                "/sbg-preprocess-workflow.test.yml",
+                # "dev": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.dev.yml",
+                # "test": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.test.yml",
+                "dev": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/preprocess/sbg-preprocess-workflow.dev.yml",
+                "test": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/preprocess/sbg-preprocess-workflow.test.yml",
             },
             "request_storage": "10Gi",
             # c6i.xlarge: 4vCPUs, 8 GB memory
             # r7i.xlarge: 4 CPUs 32 GB memory
             "request_instance_type": "r7i.xlarge",
-            "use_ecr": False,
         },
     },
 }
@@ -108,7 +101,6 @@ def trigger_dag(airflow_api_url, airflow_api_auth, venue, test_case, test_dag):
             "conf": {
                 "request_storage": f'{DAG_PARAMETERS[test_dag][test_case]["request_storage"]}',
                 "request_instance_type": f'{DAG_PARAMETERS[test_dag][test_case]["request_instance_type"]}',
-                "use_ecr": DAG_PARAMETERS[test_dag][test_case]["use_ecr"],
             }
         }
 

--- a/unity-test/system/integration/step_defs/test_cwl_workflows_with_ogc_api.py
+++ b/unity-test/system/integration/step_defs/test_cwl_workflows_with_ogc_api.py
@@ -82,7 +82,6 @@ CWL_DAG_MODULAR_DATA = {
             },
             "request_storage": "10Gi",
             "request_instance_type": "t3.medium",
-            "use_ecr": False,
         },
         "outputs": {"result": {"transmissionMode": "reference"}},
     },

--- a/unity-test/system/integration/step_defs/test_cwl_workflows_with_ogc_api.py
+++ b/unity-test/system/integration/step_defs/test_cwl_workflows_with_ogc_api.py
@@ -24,47 +24,44 @@ CWL_DAG_MODULAR_ID = "cwl_dag_modular"
 CWL_DAG_DATA = {
     "EMIT": {
         "inputs": {
-            "cwl_workflow": "http://awslbdockstorestack-lb-1429770210.us-west-2.elb.amazonaws.com:9998/api/ga4gh/trs/v2/tools/%23workflow%2Fdockstore.org%2FGodwinShen%2Femit-ghg/versions/9/plain-CWL/descriptor/workflow.cwl",
+            # "cwl_workflow": "http://awslbdockstorestack-lb-1429770210.us-west-2.elb.amazonaws.com:9998/api/ga4gh/trs/v2/tools/%23workflow%2Fdockstore.org%2FGodwinShen%2Femit-ghg/versions/9/plain-CWL/descriptor/workflow.cwl",
+            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/emit/GodwinShen/workflow.cwl",
             "cwl_args": {
-                "dev": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main/test/emit-ghg-dev.json"
+                # "dev": "https://raw.githubusercontent.com/GodwinShen/emit-ghg/refs/heads/main/test/emit-ghg-dev.json"
+                "dev": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/emit/GodwinShen/emit-ghg-dev.json",
             },
             "request_storage": "100Gi",
             # r7i.2xlarge: 8 CPUs, 64 GB memory
             "request_instance_type": "r7i.2xlarge",
-            "use_ecr": False,
         },
         "outputs": {"result": {"transmissionMode": "reference"}},
     },
     "SBG_PREPROCESS": {
         "inputs": {
-            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main"
-            "/preprocess/sbg-preprocess-workflow.cwl",
+            # "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.cwl",
+            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/preprocess/sbg-preprocess-workflow.cwl",
             "cwl_args": {
-                "dev": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess"
-                "/sbg-preprocess-workflow.dev.yml",
-                "test": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess"
-                "/sbg-preprocess-workflow.test.yml",
+                # "dev": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.dev.yml",
+                "dev": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/preprocess/sbg-preprocess-workflow.dev.yml",
+                # "test": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/main/preprocess/sbg-preprocess-workflow.test.yml",
+                "test": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/preprocess/sbg-preprocess-workflow.test.yml",
             },
             "request_storage": "10Gi",
-            # c6i.xlarge: 4vCPUs, 8 GB memory
-            # r7i.xlarge: 4 CPUs 32 GB memory
             "request_instance_type": "r7i.xlarge",
-            "use_ecr": False,
         },
         "outputs": {"result": {"transmissionMode": "reference"}},
     },
     "SBG_E2E_SCALE": {
         "inputs": {
-            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/"
-            "sbg-workflows/refs/heads/main/L1-to-L2-e2e.cwl",
+            # "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/refs/heads/main/L1-to-L2-e2e.cwl",
+            "cwl_workflow": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/l1-to-l2-e2e/L1-to-L2-e2e.cwl",
             "cwl_args": {
-                "dev": "https://raw.githubusercontent.com/unity-sds/"
-                "sbg-workflows/refs/heads/main/L1-to-L2-e2e.dev.yml",
+                # "dev": "https://raw.githubusercontent.com/unity-sds/sbg-workflows/refs/heads/main/L1-to-L2-e2e.dev.yml",
+                "dev": "https://raw.githubusercontent.com/unity-sds/unity-sps-workflows/refs/heads/main/sbg/l1-to-l2-e2e/L1-to-L2-e2e.dev.yml",
             },
             "request_storage": "100Gi",
             # c6i.8xlarge: 32 CPUs, 64 GB memory
             "request_instance_type": "c6i.8xlarge",
-            "use_ecr": False,
         },
         "outputs": {"result": {"transmissionMode": "reference"}},
     },


### PR DESCRIPTION
## Purpose

- This PR updates all currently supported test cases for the CWL workflow to use the latest version of the Data Services container: 9.11.1

## Proposed Changes

- [CHANGE] Reference the Docker container ghcr.io/unity-sds/unity-data-services:9.11.1
- [CHANGE] Reference CWL workflows in the "unity-sps-workflows" GitHub repository

## Issues

- [Update tests for CWL (classic) DAG to use the latest version of the Data Services container (9.11.1)](https://github.com/unity-sds/unity-sps/issues/396)

## Testing

- Executed all tests on SPS instance "luca-1" on unity-venue-dev to success, using both the OGC and Airflow API

