### PR TITLE
API Gateway path adjustment to be in-line with CS directives

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -653,7 +653,7 @@ resource "time_sleep" "wait_for_gateway_integration" {
 # API Gateway deployment
 resource "aws_api_gateway_deployment" "airflow-api-gateway-deployment" {
   rest_api_id = data.aws_api_gateway_rest_api.rest_api.id
-  stage_name  = var.venue
+  stage_name  = "default"
   depends_on  = [time_sleep.wait_for_gateway_integration, aws_api_gateway_method_response.response_200]
 }
 

--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -420,7 +420,7 @@ resource "time_sleep" "wait_for_gateway_integration" {
 # API Gateway deployment
 resource "aws_api_gateway_deployment" "ogc-api-gateway-deployment" {
   rest_api_id = data.aws_api_gateway_rest_api.rest_api.id
-  stage_name  = var.venue
+  stage_name  = "default"
   depends_on  = [time_sleep.wait_for_gateway_integration, aws_api_gateway_method_response.response_200]
 }
 


### PR DESCRIPTION
## Purpose

- Really quick PR to adjust the pathing of the deployed apigateway to match CS's usage.
  - [CS's deployment](https://github.com/unity-sds/unity-cs-infra/blob/main/terraform-project-api-gateway_module/main.tf#L236-L242)

## Proposed Changes

- CHANGE the stage name from the $venue to "default"

## Issues

- No relevant issues