### PR TITLE
Update default OGC Processes API container image tag

### DIFF
--- a/terraform-unity/variables.tf
+++ b/terraform-unity/variables.tf
@@ -97,7 +97,7 @@ variable "ogc_processes_docker_images" {
   default = {
     ogc_processes_api = {
       name = "ghcr.io/unity-sds/unity-sps-ogc-processes-api/unity-sps-ogc-processes-api"
-      tag  = "2.0.0"
+      tag  = "2.1.0"
     }
     git_sync = {
       name = "registry.k8s.io/git-sync/git-sync"


### PR DESCRIPTION
## Purpose

- Default OGC processes API container image tag to accommodate updated API operations that allow users to update a process

## Proposed Changes

- [CHANGE] Default OGC processes API container image tag

## Issues

- #408 

## Testing

- Deployed to `unity-venue-dev` and tested deploy, replace (update), and un-deploy OGC API endpoints
