### PR TITLE
Added new field, `isPortalIntegrated`, to the health endpoint metadata.

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-airflow/main.tf
@@ -681,6 +681,7 @@ resource "aws_ssm_parameter" "airflow_ui_health_check_endpoint" {
     "componentType" : "ui"
     "description" : "The primary GUI for the Science Processing System (SPS) to run and monitor jobs at scale."
     "healthCheckUrl" : "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/sps/health"
+    "isPortalIntegrated" : false
     "landingPageUrl" : "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/sps/"
   })
   tags = merge(local.common_tags, {
@@ -717,6 +718,7 @@ resource "aws_ssm_parameter" "airflow_api_health_check_endpoint" {
     "componentType" : "api"
     "description" : "The direct API for the job management system underlying the SPS (Airflow). Typically the OGC Processes API should be used instead, because it will abstract out a particular job engine."
     "healthCheckUrl" : "${aws_api_gateway_deployment.airflow-api-gateway-deployment.invoke_url}/sps/api/v1/health"
+    "isPortalIntegrated" : false
     "landingPageUrl" : "${aws_api_gateway_deployment.airflow-api-gateway-deployment.invoke_url}/sps/api/v1"
   })
   tags = merge(local.common_tags, {


### PR DESCRIPTION
## Purpose

Added the new field, `isPortalIntegrated`, to the health endpoint information. Set the field to be `false` which informs the portal that the respective service, if it is a UI, should be opened in a new window if accessed from the portal's menu.

## Proposed Changes

- [ADD] New metadata field, `isPortalIntegrated` to the health endpoint metadata

## Issues

- https://github.com/unity-sds/ui-ux/issues/8

