### PR TITLE
Added new field, `isPortalIntegrated`, to the health endpoint metadata.

### DIFF
--- a/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
+++ b/terraform-unity/modules/terraform-unity-sps-ogc-processes-api/main.tf
@@ -461,6 +461,7 @@ resource "aws_ssm_parameter" "ogc_processes_api_health_check_endpoint" {
     "componentType" : "api"
     "description" : "A standards-compliant programming interface for Application deployment, job execution and job tracking. May be used to execute jobs in batches."
     "healthCheckUrl" : "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/ogc/health"
+    "isPortalIntegrated" : false
     "landingPageUrl" : "https://www.${data.aws_ssm_parameter.shared_services_domain.value}:4443/${var.project}/${var.venue}/ogc/"
   })
   tags = merge(local.common_tags, {


### PR DESCRIPTION
## Purpose

Added the new field, `isPortalIntegrated`, to the health endpoint information. Set the field to be `false` which informs the portal that the respective service, if it is a UI, should be opened in a new window if accessed from the portal's menu.

## Proposed Changes

- [ADD] New metadata field, `isPortalIntegrated` to the health endpoint metadata

## Issues

- https://github.com/unity-sds/ui-ux/issues/8
