### PR TITLE
Update airflow and keda helm charts

### DIFF
--- a/terraform-unity/variables.tf
+++ b/terraform-unity/variables.tf
@@ -52,12 +52,12 @@ variable "helm_charts" {
     airflow = {
       repository = "https://airflow.apache.org"
       chart      = "airflow"
-      version    = "1.15.0"
+      version    = "1.18.0"
     },
     keda = {
       repository = "https://kedacore.github.io/charts"
       chart      = "keda"
-      version    = "v2.15.1"
+      version    = "v2.17.2"
     }
   }
 }


### PR DESCRIPTION
## Purpose

- Upgrade to most recent helm charts for Airflow and KEDA to support the upgrade to Airflow 3.0

## Proposed Changes

- [CHANGE] version 1.18.0 for Airflow Helm chart and 2.17.2 for KEDA Helm chart

## Issues

- #429 

## Testing

- I was able to deploy this previously but am currently having trouble with my SPS deployment so I am in the process of testing.
